### PR TITLE
initialize codex with the step objective as argv

### DIFF
--- a/src/governing_docs/application_interface.md
+++ b/src/governing_docs/application_interface.md
@@ -216,6 +216,7 @@ Expected outcome on success:
 - Resolves the workflow file from the selected local tree using the requested workflow path.
 - Loads and validates the authored workflow definition.
 - Executes the workflow's steps in order.
+- Launches each configured workflow agent with the authored step prompt supplied at process start.
 - Allows later steps to reference completed state from earlier steps.
 - Returns success only after all workflow steps complete in order.
 

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -134,6 +134,7 @@ def _build_step_prompt(
             _dump_yaml_block(output_template),
             "",
             "Return only the completion JSON object when the objective is complete.",
+            "You may return plain text only if following objective instructions, like asking questions to the user",
         ]
     )
     return "\n".join(sections)
@@ -149,15 +150,15 @@ def _run_step_session(
 ) -> PtyRunResult:
     """
     Pseudocode:
-    1. Start the configured PTY-backed agent session.
-    2. Send the canonical step prompt as the initial input.
+    1. Start the configured PTY-backed agent session with the step prompt in argv.
+    2. Do not inject an initial PTY input after launch.
     3. Feed streamed output chunks into the completion watcher.
     4. Translate timeout and launch failures into executor-specific errors.
     """
     try:
         return run_pty_session(
-            agent_config["argv"],
-            prompt_text,
+            [*agent_config["argv"], prompt_text],
+            None,
             lambda chunk: _handle_output_chunk(chunk, watcher, agent_config),
             inactivity_timeout_seconds=inactivity_timeout_seconds,
             graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -130,7 +130,7 @@ def _build_step_prompt(
             "Objective:",
             objective_text,
             "",
-            "Output template:",
+            "Output template (strict):",
             _dump_yaml_block(output_template),
             "",
             "Return only the completion JSON object when the objective is complete.",

--- a/tests/test_step_executor.py
+++ b/tests/test_step_executor.py
@@ -107,7 +107,7 @@ def test_completion_watcher_prefers_most_recent_completion_attempt():
 
 
 def test_execute_step_returns_completed_result(monkeypatch):
-    recorded_initial_input: dict[str, str] = {}
+    recorded_launch: dict[str, Any] = {}
 
     def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
         return {
@@ -124,10 +124,10 @@ def test_execute_step_returns_completed_result(monkeypatch):
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv == ["fake-agent"]
+        recorded_launch["argv"] = argv
+        recorded_launch["initial_input"] = initial_input
         assert inactivity_timeout_seconds == 300
         assert graceful_shutdown_timeout_seconds == 30
-        recorded_initial_input["value"] = initial_input or ""
 
         chunk = b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
         injected = on_output(chunk)
@@ -150,15 +150,18 @@ def test_execute_step_returns_completed_result(monkeypatch):
 
     assert result.status == "completed"
     assert result.output == {"summary": "done"}
-    assert "Objective:" in recorded_initial_input["value"]
-    assert "Output template:" in recorded_initial_input["value"]
-    assert "Write a summary." in recorded_initial_input["value"]
-    assert "Input:" not in recorded_initial_input["value"]
+    prompt_text = recorded_launch["argv"][-1]
+    assert recorded_launch["argv"][:-1] == ["fake-agent"]
+    assert recorded_launch["initial_input"] is None
+    assert "Objective:" in prompt_text
+    assert "Output template:" in prompt_text
+    assert "Write a summary." in prompt_text
+    assert "Input:" not in prompt_text
     assert result.resolved_input is None
 
 
 def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatch):
-    recorded_initial_input: dict[str, str] = {}
+    recorded_launch: dict[str, Any] = {}
 
     def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
         return {
@@ -175,7 +178,8 @@ def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatc
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        recorded_initial_input["value"] = initial_input or ""
+        recorded_launch["argv"] = argv
+        recorded_launch["initial_input"] = initial_input
         chunk = b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
         on_output(chunk)
         return PtyRunResult(exit_code=0, transcript=chunk.decode("utf-8"))
@@ -197,7 +201,8 @@ def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatc
 
     assert result.status == "completed"
     assert result.resolved_input is None
-    assert "Input:" not in recorded_initial_input["value"]
+    assert recorded_launch["initial_input"] is None
+    assert "Input:" not in recorded_launch["argv"][-1]
 
 
 def test_execute_step_returns_failed_result_for_reference_resolution_errors(monkeypatch):
@@ -312,7 +317,9 @@ def test_execute_step_returns_failed_result_when_completion_is_missing(monkeypat
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv == ["fake-agent"]
+        assert argv[:-1] == ["fake-agent"]
+        assert "Write a summary." in argv[-1]
+        assert initial_input is None
         on_output(b"still thinking\n")
         return PtyRunResult(exit_code=0, transcript="still thinking\n")
 


### PR DESCRIPTION
Runs the pty session with `[*agent_config["argv"], prompt_text]` instead of just `agent_config["argv"]`

This solves the startup timing issue