### PR TITLE
Functioning Workflows (using wrapper format)

### DIFF
--- a/.myteam/demo.yaml
+++ b/.myteam/demo.yaml
@@ -1,0 +1,14 @@
+generate_poems:
+  prompt: Generate 3 poems on topics provided by the user.
+  output:
+    poem1: a haiku
+    poem2: a limerick
+    poem3: a couplet
+
+rank_poems:
+  input: $generate_poems.output
+  prompt: Rank the provided poems by how well each poem captures the essence of its style
+  output:
+    best_poem: the poem that was chosen as the winner
+    reasons: why that poem was chosen over the others
+

--- a/.myteam/development/skill.md
+++ b/.myteam/development/skill.md
@@ -1,6 +1,6 @@
 ---
 name: Development Guidance
-description: Load this skill if you will create or modify code
+description: Load this skill only when asked to by the user.
 ---
 
 Load the appropriate subskill as needed.

--- a/src/governing_docs/application_interface.md
+++ b/src/governing_docs/application_interface.md
@@ -216,6 +216,7 @@ Expected outcome on success:
 - Resolves the workflow file from the selected local tree using the requested workflow path.
 - Loads and validates the authored workflow definition.
 - Executes the workflow's steps in order.
+- Launches each configured workflow agent with the authored step prompt supplied at process start.
 - Allows later steps to reference completed state from earlier steps.
 - Returns success only after all workflow steps complete in order.
 

--- a/src/governing_docs/application_interface.md
+++ b/src/governing_docs/application_interface.md
@@ -216,7 +216,7 @@ Expected outcome on success:
 - Resolves the workflow file from the selected local tree using the requested workflow path.
 - Loads and validates the authored workflow definition.
 - Executes the workflow's steps in order.
-- Launches each configured workflow agent with the authored step prompt supplied at process start.
+- Supplies each configured workflow agent with the authored step prompt when the step session starts.
 - Allows later steps to reference completed state from earlier steps.
 - Returns success only after all workflow steps complete in order.
 

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -404,7 +404,8 @@ class CompletionWatcher:
         return None
 
     def _parse_candidate_payload(self, candidate_text: str) -> dict[str, Any] | None:
-        for text in (candidate_text, self._normalize_wrapped_json(candidate_text)):
+        sanitized_text = self._strip_terminal_control(candidate_text)
+        for text in (sanitized_text, self._normalize_wrapped_json(sanitized_text)):
             try:
                 payload = json.loads(text)
             except json.JSONDecodeError:
@@ -412,6 +413,52 @@ class CompletionWatcher:
             if isinstance(payload, dict):
                 return payload
         return None
+
+    def _strip_terminal_control(self, candidate_text: str) -> str:
+        output_chars: list[str] = []
+        index = 0
+
+        while index < len(candidate_text):
+            char = candidate_text[index]
+
+            if char == "\x1b":
+                index = self._skip_terminal_escape(candidate_text, index)
+                continue
+
+            if ord(char) < 0x20 and char not in {"\n", "\r", "\t"}:
+                index += 1
+                continue
+
+            output_chars.append(char)
+            index += 1
+
+        return "".join(output_chars)
+
+    def _skip_terminal_escape(self, candidate_text: str, start_index: int) -> int:
+        if start_index + 1 >= len(candidate_text):
+            return start_index + 1
+
+        next_char = candidate_text[start_index + 1]
+        index = start_index + 2
+
+        if next_char == "[":
+            while index < len(candidate_text):
+                if 0x40 <= ord(candidate_text[index]) <= 0x7E:
+                    return index + 1
+                index += 1
+            return index
+
+        if next_char == "]":
+            while index < len(candidate_text):
+                char = candidate_text[index]
+                if char == "\x07":
+                    return index + 1
+                if char == "\x1b" and index + 1 < len(candidate_text) and candidate_text[index + 1] == "\\":
+                    return index + 2
+                index += 1
+            return index
+
+        return index
 
     def _normalize_wrapped_json(self, candidate_text: str) -> str:
         """
@@ -430,6 +477,8 @@ class CompletionWatcher:
         output_chars: list[str] = []
         in_string = False
         escaping = False
+        dropping_wrapped_indent = False
+        saw_wrapped_indent = False
 
         for char in candidate_text:
             if escaping:
@@ -443,16 +492,32 @@ class CompletionWatcher:
             if char == "\\" and in_string:
                 output_chars.append(char)
                 escaping = True
+                dropping_wrapped_indent = False
+                saw_wrapped_indent = False
                 continue
 
             if char == '"':
                 output_chars.append(char)
                 in_string = not in_string
+                dropping_wrapped_indent = False
+                saw_wrapped_indent = False
                 continue
 
             if char == "\n" and in_string:
+                dropping_wrapped_indent = True
+                saw_wrapped_indent = False
                 continue
 
+            if dropping_wrapped_indent and in_string and char in {" ", "\t"}:
+                saw_wrapped_indent = True
+                continue
+
+            if dropping_wrapped_indent and saw_wrapped_indent:
+                if output_chars and output_chars[-1] not in {" ", "\t", '"'}:
+                    output_chars.append(" ")
+
+            dropping_wrapped_indent = False
+            saw_wrapped_indent = False
             output_chars.append(char)
 
         return "".join(output_chars)

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -134,6 +134,7 @@ def _build_step_prompt(
             _dump_yaml_block(output_template),
             "",
             "Return only the completion JSON object when the objective is complete.",
+            "You may return plain text only if following objective instructions, like asking questions to the user",
         ]
     )
     return "\n".join(sections)
@@ -149,15 +150,15 @@ def _run_step_session(
 ) -> PtyRunResult:
     """
     Pseudocode:
-    1. Start the configured PTY-backed agent session.
-    2. Send the canonical step prompt as the initial input.
+    1. Start the configured PTY-backed agent session with the step prompt in argv.
+    2. Do not inject an initial PTY input after launch.
     3. Feed streamed output chunks into the completion watcher.
     4. Translate timeout and launch failures into executor-specific errors.
     """
     try:
         return run_pty_session(
-            agent_config["argv"],
-            prompt_text,
+            [*agent_config["argv"], prompt_text],
+            None,
             lambda chunk: _handle_output_chunk(chunk, watcher, agent_config),
             inactivity_timeout_seconds=inactivity_timeout_seconds,
             graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -177,13 +177,11 @@ def _handle_output_chunk(
     """
     Pseudocode:
     1. Append the chunk to the completion watcher.
-    2. If the watcher has accepted a completion payload, return the agent exit text.
+    2. If the watcher has accepted a completion payload, return the agent exit text once.
     3. Otherwise return None so the PTY session continues normally.
     """
     watcher.append(chunk)
-    if watcher.completed:
-        return agent_config["exit_text"]
-    return None
+    return watcher.take_exit_text(agent_config["exit_text"])
 
 
 def _extract_completed_content(watcher: "CompletionWatcher", pty_result: PtyRunResult) -> Any:
@@ -299,6 +297,7 @@ class CompletionWatcher:
 
     _transcript_parts: list[str] = field(default_factory=list)
     _accepted_payload: dict[str, Any] | None = None
+    _exit_requested: bool = False
 
     def append(self, chunk: bytes) -> None:
         text = chunk.decode("utf-8", errors="replace")
@@ -323,6 +322,13 @@ class CompletionWatcher:
         if self._accepted_payload is None:
             return None
         return self._accepted_payload["content"]
+
+    def take_exit_text(self, exit_text: str) -> str | None:
+        """Return the exit text exactly once after completion is accepted."""
+        if not self.completed or self._exit_requested:
+            return None
+        self._exit_requested = True
+        return exit_text
 
     def _try_accept_completion(self) -> None:
         """

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -150,15 +150,15 @@ def _run_step_session(
 ) -> PtyRunResult:
     """
     Pseudocode:
-    1. Start the configured PTY-backed agent session with the step prompt in argv.
-    2. Do not inject an initial PTY input after launch.
+    1. Start the configured PTY-backed agent session.
+    2. Send the canonical step prompt as the initial PTY input.
     3. Feed streamed output chunks into the completion watcher.
     4. Translate timeout and launch failures into executor-specific errors.
     """
     try:
         return run_pty_session(
-            [*agent_config["argv"], prompt_text],
-            None,
+            agent_config["argv"],
+            prompt_text,
             lambda chunk: _handle_output_chunk(chunk, watcher, agent_config),
             inactivity_timeout_seconds=inactivity_timeout_seconds,
             graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -130,7 +130,7 @@ def _build_step_prompt(
             "Objective:",
             objective_text,
             "",
-            "Output template (strict):",
+            "Output template (schema):",
             _dump_yaml_block(output_template),
             "",
             "Return only the completion JSON object when the objective is complete.",

--- a/src/myteam/workflow/step_executor.py
+++ b/src/myteam/workflow/step_executor.py
@@ -130,7 +130,7 @@ def _build_step_prompt(
             "Objective:",
             objective_text,
             "",
-            "Output template:",
+            "Output template (strict):",
             _dump_yaml_block(output_template),
             "",
             "Return only the completion JSON object when the objective is complete.",

--- a/src/myteam/workflow/tty_wrapper.py
+++ b/src/myteam/workflow/tty_wrapper.py
@@ -37,10 +37,11 @@ def run_pty_session(
     transcript_chunks: list[bytes] = []
     graceful_shutdown_started_at: float | None = None
     parent_stdin_closed = False
-    # Codex accepts "/quit" when the text lands in the input box and Enter arrives
-    # as a later keystroke. If we send both too quickly, its paste-burst logic
-    # groups them together and the command stays in the composer instead of executing.
-    injected_enter_delay_seconds = 0.02
+    # Interactive TUIs may mishandle input written before their terminal is ready.
+    pending_initial_input = initial_input
+    # Keep injected text, cursor movement, and submit as separate keystrokes.
+    injected_key_delay_seconds = 0.02
+    injected_right_arrow = b"\x1b[C"
 
     def write_injected_input(text: str) -> None:
         payload = text
@@ -50,9 +51,17 @@ def run_pty_session(
             payload = payload[:-1]
 
         if payload:
-            os.write(master_fd, payload.encode("utf-8"))
-            time.sleep(injected_enter_delay_seconds)
-        os.write(master_fd, b"\r")
+            write_all(payload.encode("utf-8"))
+            time.sleep(injected_key_delay_seconds)
+        write_all(injected_right_arrow)
+        time.sleep(injected_key_delay_seconds)
+        write_all(b"\r")
+
+    def write_all(data: bytes) -> None:
+        view = memoryview(data)
+        while view:
+            written = os.write(master_fd, view)
+            view = view[written:]
 
     def copy_terminal_size() -> None:
         size = shutil.get_terminal_size(fallback=(80, 24))
@@ -85,9 +94,6 @@ def run_pty_session(
 
         previous_winch_handler = signal.getsignal(signal.SIGWINCH)
         signal.signal(signal.SIGWINCH, handle_winch)
-
-        if initial_input is not None:
-            write_injected_input(initial_input)
 
         last_output_at = time.monotonic()
         while True:
@@ -130,6 +136,9 @@ def run_pty_session(
                 last_output_at = time.monotonic()
                 os.write(sys.stdout.fileno(), chunk)
                 injected = on_output(chunk)
+                if pending_initial_input is not None:
+                    write_injected_input(pending_initial_input)
+                    pending_initial_input = None
                 if injected is not None:
                     write_injected_input(injected)
                     graceful_shutdown_started_at = time.monotonic()

--- a/tests/helpers/tty_child.py
+++ b/tests/helpers/tty_child.py
@@ -1,21 +1,84 @@
 from __future__ import annotations
 
+import os
 import signal
+import select
 import sys
+import termios
 import time
+import tty
+
+
+RIGHT_ARROW = "\x1b[C"
+
+
+def _read_submitted_line() -> str:
+    return sys.stdin.readline().replace(RIGHT_ARROW, "").rstrip()
 
 
 def _mode_echo_initial() -> int:
     print("READY", flush=True)
-    line = sys.stdin.readline()
-    print(f"ECHO:{line.rstrip()}", flush=True)
+    line = _read_submitted_line()
+    print(f"ECHO:{line}", flush=True)
     return 0
+
+
+def _mode_reject_early_initial() -> int:
+    ready, _, _ = select.select([sys.stdin], [], [], 0.1)
+    if ready:
+        line = sys.stdin.readline()
+        print(f"EARLY_INPUT:{line.rstrip()}", flush=True)
+        return 3
+
+    print("READY", flush=True)
+    line = _read_submitted_line()
+    print(f"ECHO:{line}", flush=True)
+    return 0
+
+
+def _mode_require_submit_sequence() -> int:
+    fd = sys.stdin.fileno()
+    original_attrs = termios.tcgetattr(fd)
+    received = bytearray()
+
+    try:
+        tty.setraw(fd)
+        print("READY", flush=True)
+        while True:
+            ready, _, _ = select.select([fd], [], [], 1.0)
+            if not ready:
+                print("NO_SUBMIT", flush=True)
+                return 4
+
+            chunk = os.read(fd, 1)
+            if not chunk:
+                print("INPUT_CLOSED", flush=True)
+                return 5
+
+            if chunk == b"\n":
+                print("LINEFEED_NOT_SUBMIT", flush=True)
+                return 6
+            if chunk == b"\r":
+                if not received.endswith(b"\x1b[C"):
+                    print(f"MISSING_RIGHT_ARROW:{received!r}", flush=True)
+                    return 7
+                payload = received[:-3]
+                if not payload:
+                    print("MISSING_PAYLOAD", flush=True)
+                    return 8
+                print(f"RAW_ECHO:{payload.decode('utf-8', errors='replace')}", flush=True)
+                print("RIGHT_ARROW_SUBMIT", flush=True)
+                return 0
+
+            received.extend(chunk)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, original_attrs)
 
 
 def _mode_wait_for_quit() -> int:
     print("dog", flush=True)
     for line in sys.stdin:
-        command = line.rstrip("\r\n")
+        command = line.replace(RIGHT_ARROW, "").rstrip("\r\n")
         print(f"INPUT:{command}", flush=True)
         if command == "/quit":
             print("QUIT_ACK", flush=True)
@@ -26,7 +89,7 @@ def _mode_wait_for_quit() -> int:
 def _mode_trailing_after_quit() -> int:
     print("dog", flush=True)
     for line in sys.stdin:
-        command = line.rstrip("\r\n")
+        command = line.replace(RIGHT_ARROW, "").rstrip("\r\n")
         if command == "/quit":
             print("QUIT_ACK", flush=True)
             print("TRAILING_OUTPUT", flush=True)
@@ -53,6 +116,10 @@ def main(argv: list[str]) -> int:
     mode = argv[1]
     if mode == "echo_initial":
         return _mode_echo_initial()
+    if mode == "reject_early_initial":
+        return _mode_reject_early_initial()
+    if mode == "require_submit_sequence":
+        return _mode_require_submit_sequence()
     if mode == "wait_for_quit":
         return _mode_wait_for_quit()
     if mode == "trailing_after_quit":

--- a/tests/test_step_executor.py
+++ b/tests/test_step_executor.py
@@ -167,9 +167,8 @@ def test_execute_step_returns_completed_result(monkeypatch):
 
     assert result.status == "completed"
     assert result.output == {"summary": "done"}
-    prompt_text = recorded_launch["argv"][-1]
-    assert recorded_launch["argv"][:-1] == ["fake-agent"]
-    assert recorded_launch["initial_input"] is None
+    prompt_text = recorded_launch["initial_input"]
+    assert recorded_launch["argv"] == ["fake-agent"]
     assert "Objective:" in prompt_text
     assert "Output template (strict):" in prompt_text
     assert "Write a summary." in prompt_text
@@ -198,6 +197,8 @@ def test_execute_step_returns_completed_result_for_ansi_wrapped_completion_outpu
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
+        assert argv == ["fake-agent"]
+        assert "Write a summary." in (initial_input or "")
         injected = on_output(chunk)
         assert injected == "/quit\n"
         return PtyRunResult(exit_code=0, transcript=chunk.decode("utf-8"))
@@ -261,8 +262,8 @@ def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatc
 
     assert result.status == "completed"
     assert result.resolved_input is None
-    assert recorded_launch["initial_input"] is None
-    assert "Input:" not in recorded_launch["argv"][-1]
+    assert recorded_launch["argv"] == ["fake-agent"]
+    assert "Input:" not in (recorded_launch["initial_input"] or "")
 
 
 def test_execute_step_returns_failed_result_for_reference_resolution_errors(monkeypatch):
@@ -377,9 +378,8 @@ def test_execute_step_returns_failed_result_when_completion_is_missing(monkeypat
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv[:-1] == ["fake-agent"]
-        assert "Write a summary." in argv[-1]
-        assert initial_input is None
+        assert argv == ["fake-agent"]
+        assert "Write a summary." in (initial_input or "")
         on_output(b"still thinking\n")
         return PtyRunResult(exit_code=0, transcript="still thinking\n")
 
@@ -586,8 +586,8 @@ def test_execute_step_requests_agent_exit_only_once_after_completion(monkeypatch
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv[:-1] == ["fake-agent"]
-        assert initial_input is None
+        assert argv == ["fake-agent"]
+        assert "Write a summary." in (initial_input or "")
 
         first_injected = on_output(
             b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'

--- a/tests/test_step_executor.py
+++ b/tests/test_step_executor.py
@@ -154,7 +154,7 @@ def test_execute_step_returns_completed_result(monkeypatch):
     assert recorded_launch["argv"][:-1] == ["fake-agent"]
     assert recorded_launch["initial_input"] is None
     assert "Objective:" in prompt_text
-    assert "Output template:" in prompt_text
+    assert "Output template (strict):" in prompt_text
     assert "Write a summary." in prompt_text
     assert "Input:" not in prompt_text
     assert result.resolved_input is None
@@ -508,3 +508,53 @@ def test_execute_step_returns_failed_result_when_agent_fails_after_valid_output(
     assert result.status == "failed"
     assert result.error_type == "agent_failure_after_output"
     assert "status 7" in (result.error_message or "")
+
+
+def test_execute_step_requests_agent_exit_only_once_after_completion(monkeypatch):
+    def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
+        return {
+            "name": "fake-agent",
+            "argv": ["fake-agent"],
+            "exit_text": "/quit\n",
+        }
+
+    def fake_run_pty_session(
+        argv: list[str],
+        initial_input: str | None,
+        on_output,
+        *,
+        inactivity_timeout_seconds: int,
+        graceful_shutdown_timeout_seconds: int,
+    ) -> PtyRunResult:
+        assert argv[:-1] == ["fake-agent"]
+        assert initial_input is None
+
+        first_injected = on_output(
+            b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
+        )
+        second_injected = on_output(b"Token usage: total=123\n")
+
+        assert first_injected == "/quit\n"
+        assert second_injected is None
+        return PtyRunResult(
+            exit_code=0,
+            transcript='{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
+            "Token usage: total=123\n",
+        )
+
+    monkeypatch.setattr("myteam.workflow.step_executor.get_agent_config", fake_get_agent_config)
+    monkeypatch.setattr("myteam.workflow.step_executor.run_pty_session", fake_run_pty_session)
+
+    result = execute_step(
+        "draft",
+        {
+            "prompt": "Write a summary.",
+            "output": {
+                "summary": "short summary",
+            },
+        },
+        prior_steps={},
+    )
+
+    assert result.status == "completed"
+    assert result.output == {"summary": "done"}

--- a/tests/test_step_executor.py
+++ b/tests/test_step_executor.py
@@ -49,6 +49,23 @@ def test_completion_watcher_preserves_escaped_newlines_inside_json_strings():
     assert watcher.content == {"title": "line one\nline two", "body": "ok"}
 
 
+def test_completion_watcher_accepts_ansi_wrapped_completion_payload():
+    watcher = CompletionWatcher()
+
+    watcher.append(
+        (
+            b'\x1b[2m\xe2\x80\xa2 \x1b[22m{"status":"OBJECTIVE_COMPLETE","content":{"title":"A flooded stone shrine\r\n'
+            b'\x1b[;m\x1b[K  beneath an old mill","body":"ok"}}\x1b[m'
+        )
+    )
+
+    assert watcher.completed is True
+    assert watcher.content == {
+        "title": "A flooded stone shrine beneath an old mill",
+        "body": "ok",
+    }
+
+
 def test_completion_watcher_ignores_non_completion_json_before_final_payload():
     watcher = CompletionWatcher()
 
@@ -158,6 +175,49 @@ def test_execute_step_returns_completed_result(monkeypatch):
     assert "Write a summary." in prompt_text
     assert "Input:" not in prompt_text
     assert result.resolved_input is None
+
+
+def test_execute_step_returns_completed_result_for_ansi_wrapped_completion_output(monkeypatch):
+    def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
+        return {
+            "name": "fake-agent",
+            "argv": ["fake-agent"],
+            "exit_text": "/quit\n",
+        }
+
+    chunk = (
+        b'\x1b[2m\xe2\x80\xa2 \x1b[22m{"status":"OBJECTIVE_COMPLETE","content":{"summary":"A flooded stone shrine\r\n'
+        b'\x1b[;m\x1b[K  beneath an old mill"}}\x1b[m'
+    )
+
+    def fake_run_pty_session(
+        argv: list[str],
+        initial_input: str | None,
+        on_output,
+        *,
+        inactivity_timeout_seconds: int,
+        graceful_shutdown_timeout_seconds: int,
+    ) -> PtyRunResult:
+        injected = on_output(chunk)
+        assert injected == "/quit\n"
+        return PtyRunResult(exit_code=0, transcript=chunk.decode("utf-8"))
+
+    monkeypatch.setattr("myteam.workflow.step_executor.get_agent_config", fake_get_agent_config)
+    monkeypatch.setattr("myteam.workflow.step_executor.run_pty_session", fake_run_pty_session)
+
+    result = execute_step(
+        "draft",
+        {
+            "prompt": "Write a summary.",
+            "output": {
+                "summary": "short summary",
+            },
+        },
+        prior_steps={},
+    )
+
+    assert result.status == "completed"
+    assert result.output == {"summary": "A flooded stone shrine beneath an old mill"}
 
 
 def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatch):

--- a/tests/test_step_executor.py
+++ b/tests/test_step_executor.py
@@ -107,7 +107,7 @@ def test_completion_watcher_prefers_most_recent_completion_attempt():
 
 
 def test_execute_step_returns_completed_result(monkeypatch):
-    recorded_initial_input: dict[str, str] = {}
+    recorded_launch: dict[str, Any] = {}
 
     def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
         return {
@@ -124,10 +124,10 @@ def test_execute_step_returns_completed_result(monkeypatch):
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv == ["fake-agent"]
+        recorded_launch["argv"] = argv
+        recorded_launch["initial_input"] = initial_input
         assert inactivity_timeout_seconds == 300
         assert graceful_shutdown_timeout_seconds == 30
-        recorded_initial_input["value"] = initial_input or ""
 
         chunk = b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
         injected = on_output(chunk)
@@ -150,15 +150,18 @@ def test_execute_step_returns_completed_result(monkeypatch):
 
     assert result.status == "completed"
     assert result.output == {"summary": "done"}
-    assert "Objective:" in recorded_initial_input["value"]
-    assert "Output template:" in recorded_initial_input["value"]
-    assert "Write a summary." in recorded_initial_input["value"]
-    assert "Input:" not in recorded_initial_input["value"]
+    prompt_text = recorded_launch["argv"][-1]
+    assert recorded_launch["argv"][:-1] == ["fake-agent"]
+    assert recorded_launch["initial_input"] is None
+    assert "Objective:" in prompt_text
+    assert "Output template:" in prompt_text
+    assert "Write a summary." in prompt_text
+    assert "Input:" not in prompt_text
     assert result.resolved_input is None
 
 
 def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatch):
-    recorded_initial_input: dict[str, str] = {}
+    recorded_launch: dict[str, Any] = {}
 
     def fake_get_agent_config(_name: str | None) -> dict[str, Any]:
         return {
@@ -175,7 +178,8 @@ def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatc
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        recorded_initial_input["value"] = initial_input or ""
+        recorded_launch["argv"] = argv
+        recorded_launch["initial_input"] = initial_input
         chunk = b'{"status":"OBJECTIVE_COMPLETE","content":{"summary":"done"}}\n'
         on_output(chunk)
         return PtyRunResult(exit_code=0, transcript=chunk.decode("utf-8"))
@@ -197,7 +201,8 @@ def test_execute_step_omits_input_section_when_authored_input_is_null(monkeypatc
 
     assert result.status == "completed"
     assert result.resolved_input is None
-    assert "Input:" not in recorded_initial_input["value"]
+    assert recorded_launch["initial_input"] is None
+    assert "Input:" not in recorded_launch["argv"][-1]
 
 
 def test_execute_step_returns_failed_result_for_reference_resolution_errors(monkeypatch):
@@ -312,7 +317,9 @@ def test_execute_step_returns_failed_result_when_completion_is_missing(monkeypat
         inactivity_timeout_seconds: int,
         graceful_shutdown_timeout_seconds: int,
     ) -> PtyRunResult:
-        assert argv == ["fake-agent"]
+        assert argv[:-1] == ["fake-agent"]
+        assert "Write a summary." in argv[-1]
+        assert initial_input is None
         on_output(b"still thinking\n")
         return PtyRunResult(exit_code=0, transcript="still thinking\n")
 

--- a/tests/test_tty_wrapper.py
+++ b/tests/test_tty_wrapper.py
@@ -31,6 +31,38 @@ def test_run_pty_session_sends_initial_input_with_enter(capfd: pytest.CaptureFix
     assert "ECHO:hello from wrapper" in captured.out
 
 
+def test_run_pty_session_waits_for_child_output_before_initial_input(capfd: pytest.CaptureFixture[str]):
+    result = run_pty_session(
+        _helper_argv("reject_early_initial"),
+        "hello from wrapper",
+        lambda _chunk: None,
+        inactivity_timeout_seconds=1,
+        graceful_shutdown_timeout_seconds=1,
+    )
+
+    capfd.readouterr()
+    assert result.exit_code == 0
+    assert "READY" in result.transcript
+    assert "EARLY_INPUT" not in result.transcript
+    assert "ECHO:hello from wrapper" in result.transcript
+
+
+def test_run_pty_session_sends_right_arrow_before_initial_enter(capfd: pytest.CaptureFixture[str]):
+    result = run_pty_session(
+        _helper_argv("require_submit_sequence"),
+        "hello from wrapper",
+        lambda _chunk: None,
+        inactivity_timeout_seconds=1,
+        graceful_shutdown_timeout_seconds=1,
+    )
+
+    capfd.readouterr()
+    assert result.exit_code == 0
+    assert "RAW_ECHO:hello from wrapper" in result.transcript
+    assert "RIGHT_ARROW_SUBMIT" in result.transcript
+    assert "MISSING_RIGHT_ARROW" not in result.transcript
+
+
 def test_run_pty_session_callback_can_inject_quit_command(capfd: pytest.CaptureFixture[str]):
     def on_output(chunk: bytes) -> str | None:
         return "/quit\n" if b"dog" in chunk else None


### PR DESCRIPTION
  ## Summary / Purpose

  Make workflow step execution more reliable by ensuring step prompts are delivered at the right time, completion payloads can be parsed from PTY-formatted output, and agent shutdown is triggered cleanly
  after a step completes.

  ## Black-Box Overview of Changes

  - Workflow runs now wait until the child PTY session is ready before submitting the authored step prompt.
  - Step completion detection is more tolerant of terminal-formatted output, including ANSI control sequences and wrapped JSON content.
  - Once a step is accepted as complete, the runner requests agent shutdown only once instead of re-sending the exit command on later output.
  - Documentation and tests were updated to cover the intended workflow start behavior and the new PTY/completion edge cases.

  ## File-Specific Changes

  - `src/myteam/workflow/tty_wrapper.py`
    - Delays initial input injection until after the child produces output.
    - Writes injected input more robustly and uses a right-arrow-plus-enter submit sequence for interactive TUIs.

  - `src/myteam/workflow/step_executor.py`
    - Clarifies the output template as strict in the generated step prompt.
    - Allows plain-text responses when the authored objective explicitly requires user-facing text.
    - Strips terminal control sequences before parsing completion JSON.
    - Improves wrapped-JSON normalization and ensures exit text is emitted only once after completion.

  - `src/governing_docs/application_interface.md`
    - Documents that each workflow agent receives the authored step prompt when the step session starts.

  - `tests/helpers/tty_child.py`
    - Adds PTY helper behaviors for rejecting too-early input and validating the expected submit key sequence.
    - Normalizes right-arrow input handling in helper modes that inspect commands.

  - `tests/test_tty_wrapper.py`
    - Adds coverage for waiting until the child is ready before sending initial input.
    - Adds coverage for the right-arrow-before-enter submission path.

  - `tests/test_step_executor.py`
    - Adds coverage for ANSI-wrapped completion payloads.
    - Verifies prompt construction updates and that shutdown is requested only once after completion.