### PR TITLE
Isolate execute step

### DIFF
--- a/.myteam/demo_workflow.py
+++ b/.myteam/demo_workflow.py
@@ -126,3 +126,6 @@ def feature_pipeline():
                 "implementation": implement_result.output,
                 "review": review_result.output
             }
+
+def main():
+    return feature_pipeline()

--- a/.myteam/demo_workflow.py
+++ b/.myteam/demo_workflow.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from myteam.workflow import execute_step
+from myteam.workflow.models import StepResult
+
+WORKFLOW_AGENT = "codex"
+
+
+def _execute_required_step(step_definition: dict) -> StepResult:
+    result = execute_step(step_definition)
+    if result.status != "completed":
+        raise RuntimeError(
+            f"Workflow step failed with {result.error_type}: {result.error_message}"
+        )
+    return result
+
+def feature_pipeline():
+    plan_step = {
+        "agent": WORKFLOW_AGENT,
+        "output": {
+            "feature_spec": "the feature request translated into an implementation-ready spec",
+            "framework_changes": "framework refactors or extensions required before feature work begins",
+            "implementation_slices": "an ordered list of small implementation slices",
+            "test_plan": "tests that should exist before and after implementation"
+        },
+        "prompt": (
+            "Plan the feature using `myteam get skill "
+            "development/feature-pipeline/framework-oriented-design`. "
+            "Produce a framework-oriented design that is ready to implement."
+        )
+    }
+    plan_result = _execute_required_step(plan_step)
+
+    framework_step = {
+        "agent": WORKFLOW_AGENT,
+        "input": plan_result.output,
+        "output": {
+            "framework_summary": "what framework changes were made and why",
+            "test_results": "results from running the existing test suite after refactoring",
+            "framework_ready": "whether the framework is ready for feature-specific test updates"
+        },
+        "prompt": (
+            "Refactor the framework if necessary, then run the tests and confirm "
+            "they all pass before proceeding."
+        )
+    }
+    framework_result = _execute_required_step(framework_step)
+
+    testing_step = {
+        "agent": WORKFLOW_AGENT,
+        "input": {
+            "plan": plan_result.output,
+            "framework": framework_result.output
+        },
+        "output": {
+            "updated_tests": "the new or updated tests needed for the feature",
+            "test_expectations": "what each test validates",
+            "testing_ready": "whether the tests are ready for implementation work"
+        },
+        "prompt": (
+            "Update the tests using `myteam get skill development/testing` so they "
+            "describe the intended feature behavior."
+        )
+    }
+    testing_result = _execute_required_step(testing_step)
+
+    implementation_state = {
+        "plan": plan_result.output,
+        "framework": framework_result.output,
+        "tests": testing_result.output,
+        "attempt": 0,
+        "latest_changes": None,
+        "latest_review": None
+    }
+
+    while True:
+        implementation_state["attempt"] += 1
+
+        implement_step = {
+            "agent": WORKFLOW_AGENT,
+            "input": implementation_state,
+            "output": {
+                "code_changes": "the code written for this implementation attempt",
+                "completed_slices": "which planned slices were completed",
+                "remaining_work": "what still needs to be implemented"
+            },
+            "prompt": "Implement the next feature slice while preserving the updated tests."
+        }
+        implement_result = _execute_required_step(implement_step)
+        implementation_state["latest_changes"] = implement_result.output
+
+        review_step = {
+            "agent": WORKFLOW_AGENT,
+            "input": {
+                "plan": plan_result.output,
+                "tests": testing_result.output,
+                "implementation": implement_result.output
+            },
+            "output": {
+                "findings": "review findings for the current implementation",
+                "ready": "true when the feature is ready to ship, otherwise false",
+                "follow_up_work": "specific changes needed before the next implementation attempt"
+            },
+            "prompt": (
+                "Review implementation using `myteam get role "
+                "development/feature-pipeline/code-linter`. Return findings and "
+                "whether or not it's ready."
+            )
+        }
+        review_result = _execute_required_step(review_step)
+        implementation_state["latest_review"] = review_result.output
+
+        if review_result.output["ready"]:
+            return {
+                "plan": plan_result.output,
+                "framework": framework_result.output,
+                "tests": testing_result.output,
+                "implementation": implement_result.output,
+                "review": review_result.output
+            }

--- a/.myteam/demo_workflow.py
+++ b/.myteam/demo_workflow.py
@@ -15,7 +15,12 @@ WORKFLOW_AGENT = "codex"
 
 
 def _execute_required_step(step_definition: dict) -> StepResult:
-    result = execute_step(step_definition)
+    result = execute_step(
+        agent=step_definition.get("agent"),
+        input=step_definition.get("input"),
+        output=step_definition["output"],
+        prompt=step_definition["prompt"],
+    )
     if result.status != "completed":
         raise RuntimeError(
             f"Workflow step failed with {result.error_type}: {result.error_message}"

--- a/.myteam/demo_workflow.py
+++ b/.myteam/demo_workflow.py
@@ -9,73 +9,68 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from myteam.workflow import execute_step
-from myteam.workflow.models import StepResult
 
 WORKFLOW_AGENT = "codex"
 
 
-def _execute_required_step(step_definition: dict) -> StepResult:
-    result = execute_step(
-        agent=step_definition.get("agent"),
-        input=step_definition.get("input"),
-        output=step_definition["output"],
-        prompt=step_definition["prompt"],
-    )
-    if result.status != "completed":
-        raise RuntimeError(
-            f"Workflow step failed with {result.error_type}: {result.error_message}"
-        )
-    return result
-
 def feature_pipeline():
-    plan_step = {
-        "agent": WORKFLOW_AGENT,
-        "output": {
+    plan_result = execute_step(
+        agent=WORKFLOW_AGENT,
+        output={
             "feature_spec": "the feature request translated into an implementation-ready spec",
             "framework_changes": "framework refactors or extensions required before feature work begins",
             "implementation_slices": "an ordered list of small implementation slices",
             "test_plan": "tests that should exist before and after implementation"
         },
-        "prompt": (
+        prompt=(
             "Plan the feature using `myteam get skill "
             "development/feature-pipeline/framework-oriented-design`. "
             "Produce a framework-oriented design that is ready to implement."
+        ),
+    )
+    if plan_result.status != "completed":
+        raise RuntimeError(
+            f"Workflow step failed with {plan_result.error_type}: {plan_result.error_message}"
         )
-    }
-    plan_result = _execute_required_step(plan_step)
 
-    framework_step = {
-        "agent": WORKFLOW_AGENT,
-        "input": plan_result.output,
-        "output": {
+    framework_result = execute_step(
+        agent=WORKFLOW_AGENT,
+        input=plan_result.output,
+        output={
             "framework_summary": "what framework changes were made and why",
             "test_results": "results from running the existing test suite after refactoring",
             "framework_ready": "whether the framework is ready for feature-specific test updates"
         },
-        "prompt": (
+        prompt=(
             "Refactor the framework if necessary, then run the tests and confirm "
             "they all pass before proceeding."
+        ),
+    )
+    if framework_result.status != "completed":
+        raise RuntimeError(
+            f"Workflow step failed with {framework_result.error_type}: {framework_result.error_message}"
         )
-    }
-    framework_result = _execute_required_step(framework_step)
 
-    testing_step = {
-        "agent": WORKFLOW_AGENT,
-        "input": {
+    testing_result = execute_step(
+        agent=WORKFLOW_AGENT,
+        input={
             "plan": plan_result.output,
             "framework": framework_result.output
         },
-        "output": {
+        output={
             "updated_tests": "the new or updated tests needed for the feature",
             "test_expectations": "what each test validates",
             "testing_ready": "whether the tests are ready for implementation work"
         },
-        "prompt": (
+        prompt=(
             "Update the tests using `myteam get skill development/testing` so they "
             "describe the intended feature behavior."
+        ),
+    )
+    if testing_result.status != "completed":
+        raise RuntimeError(
+            f"Workflow step failed with {testing_result.error_type}: {testing_result.error_message}"
         )
-    }
-    testing_result = _execute_required_step(testing_step)
 
     implementation_state = {
         "plan": plan_result.output,
@@ -89,38 +84,44 @@ def feature_pipeline():
     while True:
         implementation_state["attempt"] += 1
 
-        implement_step = {
-            "agent": WORKFLOW_AGENT,
-            "input": implementation_state,
-            "output": {
+        implement_result = execute_step(
+            agent=WORKFLOW_AGENT,
+            input=implementation_state,
+            output={
                 "code_changes": "the code written for this implementation attempt",
                 "completed_slices": "which planned slices were completed",
                 "remaining_work": "what still needs to be implemented"
             },
-            "prompt": "Implement the next feature slice while preserving the updated tests."
-        }
-        implement_result = _execute_required_step(implement_step)
+            prompt="Implement the next feature slice while preserving the updated tests.",
+        )
+        if implement_result.status != "completed":
+            raise RuntimeError(
+                f"Workflow step failed with {implement_result.error_type}: {implement_result.error_message}"
+            )
         implementation_state["latest_changes"] = implement_result.output
 
-        review_step = {
-            "agent": WORKFLOW_AGENT,
-            "input": {
+        review_result = execute_step(
+            agent=WORKFLOW_AGENT,
+            input={
                 "plan": plan_result.output,
                 "tests": testing_result.output,
                 "implementation": implement_result.output
             },
-            "output": {
+            output={
                 "findings": "review findings for the current implementation",
                 "ready": "true when the feature is ready to ship, otherwise false",
                 "follow_up_work": "specific changes needed before the next implementation attempt"
             },
-            "prompt": (
+            prompt=(
                 "Review implementation using `myteam get role "
                 "development/feature-pipeline/code-linter`. Return findings and "
                 "whether or not it's ready."
+            ),
+        )
+        if review_result.status != "completed":
+            raise RuntimeError(
+                f"Workflow step failed with {review_result.error_type}: {review_result.error_message}"
             )
-        }
-        review_result = _execute_required_step(review_step)
         implementation_state["latest_review"] = review_result.output
 
         if review_result.output["ready"]:

--- a/.myteam/development.py
+++ b/.myteam/development.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from myteam.workflow import execute_step
+from myteam.workflow.models import StepResult
+
+WORKFLOW_AGENT = "codex"
+
+
+def main(feature_request: str | None = None) -> dict[str, Any]:
+    request = collect_feature_request(feature_request)
+    branch = require_feature_branch()
+
+    interface = update_interface_doc(request, branch)
+    plan = design_feature(request, interface, branch)
+    framework = refactor_framework(plan)
+    tests = update_tests(plan, framework)
+    implementation = implement_feature(plan, framework, tests)
+    conclusion = conclude_feature(plan, implementation)
+
+    print_summary(conclusion)
+    return conclusion
+
+
+def run_step(
+    *,
+    prompt: str,
+    output: dict[str, Any],
+    input: Any | None = None,
+    agent: str = WORKFLOW_AGENT,
+) -> dict[str, Any]:
+    step_definition: dict[str, Any] = {
+        "agent": agent,
+        "prompt": prompt,
+        "output": output,
+    }
+    if input is not None:
+        step_definition["input"] = input
+
+    return require_completed(execute_step(step_definition))
+
+
+def require_completed(result: StepResult) -> dict[str, Any]:
+    if result.status != "completed":
+        raise RuntimeError(f"{result.error_type}: {result.error_message}")
+    if not isinstance(result.output, dict):
+        raise RuntimeError("Workflow step completed without a mapping output.")
+    return result.output
+
+
+def require_feature_branch() -> str:
+    branch = subprocess.check_output(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        text=True,
+    ).strip()
+    if branch == "main":
+        raise RuntimeError(
+            "Start a feature branch before running the development workflow."
+        )
+    return branch
+
+
+def collect_feature_request(feature_request: str | None = None) -> dict[str, Any]:
+    return run_step(
+        input={"feature_request": feature_request} if feature_request is not None else None,
+        prompt=(
+            "Understand the feature request. Ask clarifying questions if needed. "
+            "Return an implementation-ready summary, explicit non-goals, unresolved "
+            "questions, and whether the request is ready for interface-document work."
+        ),
+        output={
+            "summary": "",
+            "intended_behavior": "",
+            "non_goals": "",
+            "open_questions": "",
+            "ready": False,
+        },
+    )
+
+
+def update_interface_doc(request: dict[str, Any], branch: str) -> dict[str, Any]:
+    return run_step(
+        input={"request": request, "branch": branch},
+        prompt=(
+            "Read src/governing_docs/application_interface.md. Update it to describe "
+            "the requested behavior. Review the change with the user. Commit the "
+            "interface-document change only after approval."
+        ),
+        output={
+            "interface_changes": "",
+            "approved": False,
+            "commit": "",
+        },
+    )
+
+
+def design_feature(
+    request: dict[str, Any],
+    interface: dict[str, Any],
+    branch: str,
+) -> dict[str, Any]:
+    return run_step(
+        input={"request": request, "interface": interface, "branch": branch},
+        prompt=(
+            "Run `myteam get skill development/feature-pipeline/framework-oriented-design`. "
+            "Inspect the relevant code. Write src/governing_docs/feature_plans/<branch>.md "
+            "with Framework refactor and Feature addition sections. Get user approval "
+            "on the feature plan, then commit it."
+        ),
+        output={
+            "plan_path": "",
+            "framework_refactor": "",
+            "feature_addition": "",
+            "approved": False,
+            "commit": "",
+        },
+    )
+
+
+def refactor_framework(plan: dict[str, Any]) -> dict[str, Any]:
+    return run_step(
+        input=plan,
+        prompt=(
+            "Apply only the feature-neutral framework refactor from the approved plan. "
+            "The existing tests should still pass. Explain how the refactor makes the "
+            "feature implementation simpler. Get user approval, then commit."
+        ),
+        output={
+            "changes": "",
+            "test_results": "",
+            "approved": False,
+            "commit": "",
+        },
+    )
+
+
+def update_tests(plan: dict[str, Any], framework: dict[str, Any]) -> dict[str, Any]:
+    return run_step(
+        input={"plan": plan, "framework": framework},
+        prompt=(
+            "Run `myteam get skill development/testing`. Update the tests to match "
+            "the approved interface document before implementing the feature. Explain "
+            "how the tests prove the interface behavior. Get user approval, then commit."
+        ),
+        output={
+            "test_changes": "",
+            "coverage_rationale": "",
+            "approved": False,
+            "commit": "",
+        },
+    )
+
+
+def implement_feature(
+    plan: dict[str, Any],
+    framework: dict[str, Any],
+    tests: dict[str, Any],
+) -> dict[str, Any]:
+    return run_step(
+        input={"plan": plan, "framework": framework, "tests": tests},
+        prompt=(
+            "Implement the feature according to the approved plan and updated tests. "
+            "Run the relevant tests. Review the implementation with the user. Commit "
+            "only after approval."
+        ),
+        output={
+            "changes": "",
+            "test_results": "",
+            "approved": False,
+            "commit": "",
+            "remaining_work": "",
+        },
+    )
+
+
+def conclude_feature(
+    plan: dict[str, Any],
+    implementation: dict[str, Any],
+) -> dict[str, Any]:
+    review_state: dict[str, Any] = {
+        "plan": plan,
+        "implementation": implementation,
+        "attempt": 0,
+    }
+
+    while True:
+        review_state["attempt"] += 1
+        code_review, myteam_update = run_parallel_final_reviews(review_state)
+
+        if is_true(code_review["ready"]):
+            break
+
+        review_state["latest_code_review"] = code_review
+        review_state["implementation"] = address_code_review_findings(review_state)
+
+    return run_conclusion_step(
+        plan=plan,
+        implementation=review_state["implementation"],
+        code_review=code_review,
+        myteam_update=myteam_update,
+    )
+
+
+def run_parallel_final_reviews(
+    state: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        code_review_future = executor.submit(run_code_linter, state)
+        myteam_update_future = executor.submit(run_project_myteam_update, state)
+
+        code_review = code_review_future.result()
+        myteam_update = myteam_update_future.result()
+
+    return code_review, myteam_update
+
+
+def run_code_linter(state: dict[str, Any]) -> dict[str, Any]:
+    return run_step(
+        input=state,
+        prompt=(
+            "Run `myteam get role development/feature-pipeline/code-linter`. "
+            "Please confirm that this branch is ready. Do not make code changes. "
+            "Return findings, readiness, and any follow-up work."
+        ),
+        output={
+            "findings": "",
+            "ready": False,
+            "follow_up_work": "",
+        },
+    )
+
+
+def run_project_myteam_update(state: dict[str, Any]) -> dict[str, Any]:
+    return run_step(
+        input=state,
+        prompt=(
+            "Run `myteam get role development/feature-pipeline/project-myteam-update`. "
+            "Please identify and correct any needed migrations in .myteam. Return "
+            "whether migration work was needed, what changed, and any migration doc path."
+        ),
+        output={
+            "migration_needed": False,
+            "changes": "",
+            "migration_doc": "",
+        },
+    )
+
+
+def address_code_review_findings(state: dict[str, Any]) -> dict[str, Any]:
+    return run_step(
+        input=state,
+        prompt=(
+            "Address the code-linter findings. Make only the needed changes, run "
+            "relevant tests, and commit if changes were made. After this step, the "
+            "final review pair will run again."
+        ),
+        output={
+            "changes": "",
+            "test_results": "",
+            "commit": "",
+            "remaining_work": "",
+        },
+    )
+
+
+def run_conclusion_step(
+    *,
+    plan: dict[str, Any],
+    implementation: dict[str, Any],
+    code_review: dict[str, Any],
+    myteam_update: dict[str, Any],
+) -> dict[str, Any]:
+    return run_step(
+        input={
+            "plan": plan,
+            "implementation": implementation,
+            "code_review": code_review,
+            "myteam_update": myteam_update,
+        },
+        prompt=(
+            "Run `myteam get skill development/feature-pipeline/conclusion`. "
+            "Complete the semi-final/final commit logic, version bump, changelog, "
+            "README/docs updates, completed backlog movement, and final readiness report."
+        ),
+        output={
+            "version": "",
+            "changelog": "",
+            "docs": "",
+            "completed_backlog": "",
+            "final_commit": "",
+            "ready_to_push": False,
+        },
+    )
+
+
+def is_true(value: Any) -> bool:
+    return value is True or str(value).strip().lower() == "true"
+
+
+def print_summary(result: dict[str, Any]) -> None:
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myteam"
-version = "0.2.13"
+version = "0.2.14"
 description = "Agent roster CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/myteam/CHANGELOG.md
+++ b/src/myteam/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.2.14
+
+- Changed the experimental `execute_step(...)` API to accept resolved step values as explicit
+  keyword arguments instead of a full workflow `StepDefinition` mapping.
+- Moved workflow reference resolution and default-agent injection into the workflow engine so
+  single-step execution only handles agent selection, prompt construction, terminal execution, and
+  output validation.
+
 ## 0.2.13
 
 - Reworked experimental workflow completion so step agents now report structured results with

--- a/src/myteam/commands.py
+++ b/src/myteam/commands.py
@@ -1,6 +1,7 @@
 """Command implementations for the myteam CLI."""
 from __future__ import annotations
 
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -177,6 +178,22 @@ def _log(message: str) -> None:
     print(message, file=sys.stderr)
 
 
+def _run_python_workflow(path: Path) -> None:
+    module_name = f"_myteam_workflow_{path.stem}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Could not load Python workflow module from {path}.")
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    main = getattr(module, "main", None)
+    if not callable(main):
+        raise ValueError(f"Python workflow '{path.name}' must define a callable main().")
+
+    main()
+
+
 def start(workflow: str, prefix: str = DEFAULT_LOCAL_ROOT, verbose: bool = False) -> None:
     logger = _log if verbose else (lambda msg: None)
 
@@ -187,6 +204,15 @@ def start(workflow: str, prefix: str = DEFAULT_LOCAL_ROOT, verbose: bool = False
         raise SystemExit(1)
 
     logger(f"Resolved workflow '{workflow}' to {path}")
+
+    if path.suffix == ".py":
+        try:
+            _run_python_workflow(path)
+        except Exception as exc:
+            print(f"Failed to run workflow '{workflow}': {exc}", file=sys.stderr)
+            raise SystemExit(1)
+        logger(f"Workflow '{workflow}' completed successfully.")
+        return
 
     try:
         workflow_definition = load_workflow(path)

--- a/src/myteam/migrations/0.2.14.md
+++ b/src/myteam/migrations/0.2.14.md
@@ -1,0 +1,21 @@
+## 0.2.14 migration
+
+Version `0.2.14` changes the experimental workflow step executor API.
+
+### What changed
+
+- `execute_step(...)` now accepts resolved step values as keyword arguments: `prompt`, `output`,
+  `input`, and `agent`.
+- Workflow reference resolution and default-agent injection now happen in the workflow engine before
+  calling `execute_step(...)`.
+- Authored workflow YAML keeps the same `prompt`, `output`, `input`, and `agent` fields.
+
+### How to migrate an existing `.myteam` folder
+
+Most existing `.myteam` folders do not need file changes for this release.
+
+If you have copied or customized Python workflow wrappers that call `execute_step(...)` with a full
+step-definition mapping, update those calls to pass the step values as keyword arguments.
+
+For this migration, update `.myteam/.myteam-version` to `0.2.14` after any approved workflow wrapper
+updates are complete.

--- a/src/myteam/paths.py
+++ b/src/myteam/paths.py
@@ -39,12 +39,12 @@ def workflow_candidates(base: Path, workflow: str, prefix: str | Path | None = N
     requested_path = root.joinpath(*workflow.split("/"))
     candidates: list[Path] = []
 
-    if requested_path.suffix in {".yaml", ".yml"}:
+    if requested_path.suffix in {".yaml", ".yml", ".py"}:
         if requested_path.exists():
             candidates.append(requested_path)
         return candidates
 
-    for suffix in (".yaml", ".yml"):
+    for suffix in (".yaml", ".yml", ".py"):
         candidate = requested_path.with_suffix(suffix)
         if candidate.exists():
             candidates.append(candidate)

--- a/src/myteam/workflow/README.md
+++ b/src/myteam/workflow/README.md
@@ -25,7 +25,7 @@ From outside the package, the flow is:
 2. `workflow.parser.load_workflow(...)` loads and validates the authored YAML.
 3. `workflow.engine.run_workflow(...)` executes steps in authored order.
 4. For each step, `workflow.steps.execute_step(...)`:
-   - receives a resolved step definition from the engine
+   - receives the resolved step values from the engine
    - chooses the configured agent and backend
    - builds the prompt
    - runs an interactive terminal session
@@ -62,7 +62,7 @@ The terminal contract is:
   Owns multi-step orchestration, authored-order execution, fail-fast behavior, and completed-step storage.
 
 - [steps.py](steps.py)
-  Owns single-step execution: accept a fully resolved step definition, select agent/backend, build prompt, run session, validate result, and return `StepResult`.
+  Owns single-step execution: accept resolved step values, select agent/backend, build prompt, run session, validate result, and return `StepResult`.
 
 - [result_tool.py](result_tool.py)
   Owns the child-facing `myteam workflow-result` command implementation.

--- a/src/myteam/workflow/README.md
+++ b/src/myteam/workflow/README.md
@@ -25,7 +25,7 @@ From outside the package, the flow is:
 2. `workflow.parser.load_workflow(...)` loads and validates the authored YAML.
 3. `workflow.engine.run_workflow(...)` executes steps in authored order.
 4. For each step, `workflow.steps.execute_step(...)`:
-   - resolves authored input references
+   - receives a resolved step definition from the engine
    - chooses the configured agent and backend
    - builds the prompt
    - runs an interactive terminal session
@@ -47,7 +47,7 @@ The terminal contract is:
 ### Package Root
 
 - [__init__.py](__init__.py)
-  Exposes the main public workflow entrypoints: `load_workflow` and `run_workflow`.
+  Exposes the main public workflow entrypoints: `execute_step`, `load_workflow`, and `run_workflow`.
 
 - [parser.py](parser.py)
   Owns workflow-file loading and validation of the authored YAML structure.
@@ -62,7 +62,7 @@ The terminal contract is:
   Owns multi-step orchestration, authored-order execution, fail-fast behavior, and completed-step storage.
 
 - [steps.py](steps.py)
-  Owns single-step execution: resolve input, select agent/backend, build prompt, run session, validate result, and return `StepResult`.
+  Owns single-step execution: accept a fully resolved step definition, select agent/backend, build prompt, run session, validate result, and return `StepResult`.
 
 - [result_tool.py](result_tool.py)
   Owns the child-facing `myteam workflow-result` command implementation.

--- a/src/myteam/workflow/__init__.py
+++ b/src/myteam/workflow/__init__.py
@@ -2,5 +2,6 @@
 
 from .engine import run_workflow
 from .parser import load_workflow
+from .steps import execute_step
 
-__all__ = ["load_workflow", "run_workflow"]
+__all__ = ["execute_step", "load_workflow", "run_workflow"]

--- a/src/myteam/workflow/engine.py
+++ b/src/myteam/workflow/engine.py
@@ -53,7 +53,12 @@ def run_workflow(
                 error_message=str(exc),
             )
 
-        step_result = execute_step(resolved_step_definition)
+        step_result = execute_step(
+            agent=resolved_step_definition["agent"],
+            input=resolved_step_definition["input"],
+            output=resolved_step_definition["output"],
+            prompt=resolved_step_definition["prompt"],
+        )
         if step_result.status != "completed":
             if logger is not None:
                 if step_result.error_message:

--- a/src/myteam/workflow/engine.py
+++ b/src/myteam/workflow/engine.py
@@ -1,22 +1,26 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import asdict
+from copy import deepcopy
 
 import yaml
 
 from .agents import DEFAULT_AGENT
-from .models import CompletedStepState, StepDefinition, StepResult, WorkflowDefinition, WorkflowOutput, \
-    WorkflowRunResult
+from .models import (
+    CompletedStepState,
+    StepDefinition,
+    StepResult,
+    WorkflowDefinition,
+    WorkflowOutput,
+    WorkflowRunResult,
+)
+from .reference_resolver import resolve_references
 from .steps import execute_step
 
 
 def run_workflow(
         workflow: WorkflowDefinition,
         *,
-        default_agent: str = DEFAULT_AGENT,
-        inactivity_timeout_seconds: int = 300,
-        graceful_shutdown_timeout_seconds: int = 30,
         logger: Callable[[str], None] | None = None,
 ) -> WorkflowRunResult:
     """
@@ -34,14 +38,22 @@ def run_workflow(
     for step_name, step_definition in workflow.items():
         if logger is not None:
             logger(f"Starting step '{step_name}'")
-        step_result = execute_step(
-            step_name,
-            step_definition,
-            prior_steps=completed_steps,
-            default_agent=default_agent,
-            inactivity_timeout_seconds=inactivity_timeout_seconds,
-            graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,
-        )
+        try:
+            resolved_step_definition = _resolve_step_definition(
+                step_definition=step_definition,
+                prior_steps=completed_steps,
+            )
+        except ValueError as exc:
+            if logger is not None:
+                logger(f"Step '{step_name}' failed: {exc}")
+            return WorkflowRunResult(
+                status="failed",
+                output=completed_steps or None,
+                failed_step_name=step_name,
+                error_message=str(exc),
+            )
+
+        step_result = execute_step(resolved_step_definition)
         if step_result.status != "completed":
             if logger is not None:
                 if step_result.error_message:
@@ -81,7 +93,7 @@ def _build_completed_step_state(
     4. Store the completed step output payload.
     """
     if not step_result.agent_name:
-        raise ValueError(f"Completed step '{step_result.step_name}' is missing agent_name.")
+        raise ValueError("Completed step is missing agent_name.")
 
     completed_state: CompletedStepState = {
         "prompt": step_definition["prompt"],
@@ -90,3 +102,27 @@ def _build_completed_step_state(
         "output": step_result.output,
     }
     return completed_state
+
+
+def _resolve_step_definition(
+        *,
+        step_definition: StepDefinition,
+        prior_steps: WorkflowOutput,
+) -> StepDefinition:
+    resolved_step_definition = deepcopy(step_definition)
+    resolved_step_definition["agent"] = resolved_step_definition.get("agent", DEFAULT_AGENT)
+    resolved_step_definition["input"] = _resolve_step_input(
+        step_definition=step_definition,
+        prior_steps=prior_steps,
+    )
+    return resolved_step_definition
+
+
+def _resolve_step_input(
+        *,
+        step_definition: StepDefinition,
+        prior_steps: WorkflowOutput,
+):
+    if "input" not in step_definition:
+        return None
+    return resolve_references(step_definition["input"], prior_steps)

--- a/src/myteam/workflow/models.py
+++ b/src/myteam/workflow/models.py
@@ -48,7 +48,6 @@ class StepResult:
     - ``completion_missing``: the agent session ended without producing a structured result.
     - ``output_validation``: the completion payload content did not satisfy the authored output template.
     """
-    step_name: str
     status: str
     output: Any | None = None
     resolved_input: Any | None = None

--- a/src/myteam/workflow/steps.py
+++ b/src/myteam/workflow/steps.py
@@ -4,23 +4,27 @@ import json
 from typing import Any
 
 from .agents import get_agent_config, get_backend
-from .models import AgentConfig, StepDefinition, StepResult
+from .models import AgentConfig, StepResult
 from .terminal.session import run_terminal_session
 
 
 def execute_step(
-    step_definition: StepDefinition,
+    *,
+    prompt: str,
+    output: dict[str, Any],
+    input: Any = None,
+    agent: str | None = None,
 ) -> StepResult:
     transcript = ""
     try:
-        resolved_input = step_definition.get("input")
-        agent_name = _require_agent_name(step_definition)
+        resolved_input = input
+        agent_name = _require_agent_name(agent)
         agent_config = _resolve_agent_config(agent_name)
         backend = get_backend(agent_config["backend"])
         prompt_text = _build_step_prompt(
             resolved_input=resolved_input,
-            objective_text=step_definition["prompt"],
-            output_template=step_definition["output"],
+            objective_text=prompt,
+            output_template=output,
         )
         session_result = run_terminal_session(
             agent_config["argv"],
@@ -34,7 +38,7 @@ def execute_step(
                 "completion_missing",
                 "Workflow agent exited before reporting a structured result.",
             )
-        _validate_step_output(step_definition["output"], session_result.payload)
+        _validate_step_output(output, session_result.payload)
         return StepResult(
             status="completed",
             output=session_result.payload,
@@ -66,8 +70,7 @@ def execute_step(
         )
 
 
-def _require_agent_name(step_definition: StepDefinition) -> str:
-    agent_name = step_definition.get("agent")
+def _require_agent_name(agent_name: str | None) -> str:
     if not agent_name:
         raise StepExecutionError(
             "agent_resolution",

--- a/src/myteam/workflow/steps.py
+++ b/src/myteam/workflow/steps.py
@@ -3,24 +3,18 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from .agents import DEFAULT_AGENT, get_agent_config, get_backend
-from .models import AgentConfig, StepDefinition, StepResult, WorkflowOutput
-from .reference_resolver import resolve_references
+from .agents import get_agent_config, get_backend
+from .models import AgentConfig, StepDefinition, StepResult
 from .terminal.session import run_terminal_session
 
+
 def execute_step(
-    step_name: str,
     step_definition: StepDefinition,
-    *,
-    prior_steps: WorkflowOutput,
-    default_agent: str = DEFAULT_AGENT,
-    inactivity_timeout_seconds: int = 300,
-    graceful_shutdown_timeout_seconds: int = 30,
 ) -> StepResult:
     transcript = ""
     try:
-        resolved_input = _resolve_step_input(step_definition, prior_steps)
-        agent_name = step_definition.get("agent", default_agent)
+        resolved_input = step_definition.get("input")
+        agent_name = _require_agent_name(step_definition)
         agent_config = _resolve_agent_config(agent_name)
         backend = get_backend(agent_config["backend"])
         prompt_text = _build_step_prompt(
@@ -32,8 +26,7 @@ def execute_step(
             agent_config["argv"],
             initial_input=backend.encode_input(prompt_text),
             exit_input=backend.encode_exit(),
-            inactivity_timeout_seconds=inactivity_timeout_seconds,
-            graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,
+            inactivity_timeout_seconds=300,
         )
         transcript = session_result.transcript
         if session_result.payload is None:
@@ -43,7 +36,6 @@ def execute_step(
             )
         _validate_step_output(step_definition["output"], session_result.payload)
         return StepResult(
-            step_name=step_name,
             status="completed",
             output=session_result.payload,
             resolved_input=resolved_input,
@@ -53,7 +45,6 @@ def execute_step(
         )
     except StepExecutionError as exc:
         return StepResult(
-            step_name=step_name,
             status="failed",
             error_type=exc.error_type,
             error_message=exc.error_message,
@@ -61,7 +52,6 @@ def execute_step(
         )
     except TimeoutError as exc:
         return StepResult(
-            step_name=step_name,
             status="failed",
             error_type="timeout",
             error_message=str(exc),
@@ -69,7 +59,6 @@ def execute_step(
         )
     except OSError as exc:
         return StepResult(
-            step_name=step_name,
             status="failed",
             error_type="agent_launch",
             error_message=f"Failed to launch workflow agent: {exc}",
@@ -77,13 +66,14 @@ def execute_step(
         )
 
 
-def _resolve_step_input(step_definition: StepDefinition, prior_steps: WorkflowOutput) -> Any:
-    if "input" not in step_definition:
-        return None
-    try:
-        return resolve_references(step_definition["input"], prior_steps)
-    except ValueError as exc:
-        raise StepExecutionError("reference_resolution", str(exc)) from exc
+def _require_agent_name(step_definition: StepDefinition) -> str:
+    agent_name = step_definition.get("agent")
+    if not agent_name:
+        raise StepExecutionError(
+            "agent_resolution",
+            "Step definition is missing required field 'agent'.",
+        )
+    return agent_name
 
 
 def _resolve_agent_config(agent_name: str) -> AgentConfig:

--- a/src/myteam/workflow/terminal/session.py
+++ b/src/myteam/workflow/terminal/session.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 import threading
-import time
 
 from .pty_session import PtySession
 from .recording import TerminalRecording
@@ -23,7 +22,6 @@ def run_terminal_session(
     initial_input: bytes,
     exit_input: bytes,
     inactivity_timeout_seconds: int = 300,
-    graceful_shutdown_timeout_seconds: int = 30,
 ) -> TerminalSessionResult:
     recording = TerminalRecording()
     with ResultChannel() as result_channel:
@@ -36,7 +34,6 @@ def run_terminal_session(
                 session,
                 result_channel,
                 exit_input=exit_input,
-                graceful_shutdown_timeout_seconds=graceful_shutdown_timeout_seconds,
             )
 
             sent_initial_input = False
@@ -66,7 +63,6 @@ def _start_result_watcher(
     result_channel: ResultChannel,
     *,
     exit_input: bytes,
-    graceful_shutdown_timeout_seconds: int,
 ) -> None:
     def watch() -> None:
         while not result_channel.closed.is_set():
@@ -74,14 +70,6 @@ def _start_result_watcher(
             if payload is None:
                 continue
             session.enqueue_input(exit_input)
-            if graceful_shutdown_timeout_seconds > 0:
-                time.sleep(graceful_shutdown_timeout_seconds)
-                process = session.process
-                if process is not None and process.poll() is None:
-                    process.terminate()
-                    time.sleep(0.2)
-                    if process.poll() is None:
-                        process.kill()
             return
 
     threading.Thread(target=watch, daemon=True).start()

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -29,11 +29,9 @@ def test_execute_step_returns_completed_result(monkeypatch):
     monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
 
     result = execute_step(
-        {
-            "agent": "codex",
-            "prompt": "Write a summary.",
-            "output": {"summary": "short summary"},
-        }
+        agent="codex",
+        prompt="Write a summary.",
+        output={"summary": "short summary"},
     )
 
     assert result.status == "completed"
@@ -50,11 +48,9 @@ def test_execute_step_reports_missing_result(monkeypatch):
     monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
 
     result = execute_step(
-        {
-            "agent": "codex",
-            "prompt": "Write a summary.",
-            "output": {"summary": "short summary"},
-        }
+        agent="codex",
+        prompt="Write a summary.",
+        output={"summary": "short summary"},
     )
 
     assert result.status == "failed"
@@ -63,10 +59,8 @@ def test_execute_step_reports_missing_result(monkeypatch):
 
 def test_execute_step_requires_explicit_agent():
     result = execute_step(
-        {
-            "prompt": "Write a summary.",
-            "output": {"summary": "short summary"},
-        }
+        prompt="Write a summary.",
+        output={"summary": "short summary"},
     )
 
     assert result.status == "failed"
@@ -94,12 +88,10 @@ def test_execute_step_preserves_literal_input(monkeypatch):
     monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
 
     result = execute_step(
-        {
-            "agent": "codex",
-            "input": {"topic": "release notes"},
-            "prompt": "Write a summary.",
-            "output": {"summary": "short summary"},
-        }
+        agent="codex",
+        input={"topic": "release notes"},
+        prompt="Write a summary.",
+        output={"summary": "short summary"},
     )
 
     assert result.status == "completed"

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -15,13 +15,11 @@ def test_execute_step_returns_completed_result(monkeypatch):
         initial_input: bytes,
         exit_input: bytes,
         inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
     ) -> TerminalSessionResult:
         seen["argv"] = argv
         seen["initial_input"] = initial_input.decode("utf-8", errors="replace")
         seen["exit_input"] = exit_input
         seen["inactivity_timeout_seconds"] = inactivity_timeout_seconds
-        seen["graceful_shutdown_timeout_seconds"] = graceful_shutdown_timeout_seconds
         return TerminalSessionResult(
             exit_code=0,
             transcript="runner transcript",
@@ -31,12 +29,11 @@ def test_execute_step_returns_completed_result(monkeypatch):
     monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
 
     result = execute_step(
-        "draft",
         {
+            "agent": "codex",
             "prompt": "Write a summary.",
             "output": {"summary": "short summary"},
-        },
-        prior_steps={},
+        }
     )
 
     assert result.status == "completed"
@@ -53,13 +50,58 @@ def test_execute_step_reports_missing_result(monkeypatch):
     monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
 
     result = execute_step(
-        "draft",
         {
+            "agent": "codex",
             "prompt": "Write a summary.",
             "output": {"summary": "short summary"},
-        },
-        prior_steps={},
+        }
     )
 
     assert result.status == "failed"
     assert result.error_type == "completion_missing"
+
+
+def test_execute_step_requires_explicit_agent():
+    result = execute_step(
+        {
+            "prompt": "Write a summary.",
+            "output": {"summary": "short summary"},
+        }
+    )
+
+    assert result.status == "failed"
+    assert result.error_type == "agent_resolution"
+    assert result.error_message == "Step definition is missing required field 'agent'."
+
+
+def test_execute_step_preserves_literal_input(monkeypatch):
+    seen: dict[str, Any] = {}
+
+    def fake_run_terminal_session(
+        argv: list[str],
+        *,
+        initial_input: bytes,
+        exit_input: bytes,
+        inactivity_timeout_seconds: int,
+    ) -> TerminalSessionResult:
+        seen["initial_input"] = initial_input.decode("utf-8", errors="replace")
+        return TerminalSessionResult(
+            exit_code=0,
+            transcript="runner transcript",
+            payload={"summary": "done"},
+        )
+
+    monkeypatch.setattr("myteam.workflow.steps.run_terminal_session", fake_run_terminal_session)
+
+    result = execute_step(
+        {
+            "agent": "codex",
+            "input": {"topic": "release notes"},
+            "prompt": "Write a summary.",
+            "output": {"summary": "short summary"},
+        }
+    )
+
+    assert result.status == "completed"
+    assert result.resolved_input == {"topic": "release notes"}
+    assert '"topic": "release notes"' in seen["initial_input"]

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -11,21 +11,12 @@ from myteam.workflow.models import StepResult
 def test_run_workflow_executes_steps_in_authored_order(monkeypatch):
     calls: list[str] = []
 
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
-        calls.append(step_name)
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+        calls.append(step_definition["prompt"])
         return StepResult(
-            step_name=step_name,
             status="completed",
-            output={"value": step_name},
-            agent_name=default_agent,
+            output={"value": step_definition["output"]["value"]},
+            agent_name=step_definition["agent"],
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -43,7 +34,7 @@ def test_run_workflow_executes_steps_in_authored_order(monkeypatch):
         }
     )
 
-    assert calls == ["first", "second"]
+    assert calls == ["one", "two"]
     assert result.status == "completed"
     assert result.output is not None
     assert list(result.output) == ["first", "second"]
@@ -52,28 +43,18 @@ def test_run_workflow_executes_steps_in_authored_order(monkeypatch):
 def test_run_workflow_stops_at_first_failed_step(monkeypatch):
     calls: list[str] = []
 
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
-        calls.append(step_name)
-        if step_name == "second":
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+        calls.append(step_definition["prompt"])
+        if step_definition["prompt"] == "two":
             return StepResult(
-                step_name=step_name,
                 status="failed",
                 error_type="completion_missing",
                 error_message="missing completion",
             )
         return StepResult(
-            step_name=step_name,
             status="completed",
-            output={"value": step_name},
-            agent_name=default_agent,
+            output={"value": step_definition["output"]["value"]},
+            agent_name=step_definition["agent"],
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -95,7 +76,7 @@ def test_run_workflow_stops_at_first_failed_step(monkeypatch):
         }
     )
 
-    assert calls == ["first", "second"]
+    assert calls == ["one", "two"]
     assert result.status == "failed"
     assert result.failed_step_name == "second"
     assert result.error_message == "missing completion"
@@ -110,31 +91,21 @@ def test_run_workflow_stops_at_first_failed_step(monkeypatch):
 
 
 def test_run_workflow_stores_completed_step_state_for_later_references(monkeypatch):
-    seen_prior_steps: list[dict[str, Any]] = []
+    seen_step_definitions: list[dict[str, Any]] = []
 
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
-        seen_prior_steps.append(dict(prior_steps))
-        if step_name == "draft":
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+        seen_step_definitions.append(step_definition)
+        if step_definition["prompt"] == "Write a draft.":
             return StepResult(
-                step_name=step_name,
                 status="completed",
                 output={"title": "Draft Title"},
-                agent_name=default_agent,
+                agent_name=step_definition["agent"],
             )
         return StepResult(
-            step_name=step_name,
             status="completed",
             output={"reviewed_title": "Reviewed Draft Title"},
             resolved_input={"title": "Draft Title"},
-            agent_name=default_agent,
+            agent_name=step_definition["agent"],
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -159,17 +130,19 @@ def test_run_workflow_stores_completed_step_state_for_later_references(monkeypat
         }
     )
 
-    assert seen_prior_steps == [
-        {},
-        {
-            "draft": {
-                "prompt": "Write a draft.",
-                "input": None,
-                "agent": "codex",
-                "output": {"title": "Draft Title"},
-            }
-        },
-    ]
+    assert len(seen_step_definitions) == 2
+    assert seen_step_definitions[0] == {
+        "prompt": "Write a draft.",
+        "output": {"title": "draft title"},
+        "input": None,
+        "agent": "codex",
+    }
+    assert seen_step_definitions[1] == {
+        "input": {"title": "Draft Title"},
+        "prompt": "Review the draft.",
+        "output": {"reviewed_title": "reviewed title"},
+        "agent": "codex",
+    }
     assert result.status == "completed"
     assert result.output == {
         "draft": {
@@ -187,26 +160,15 @@ def test_run_workflow_stores_completed_step_state_for_later_references(monkeypat
     }
 
 
-def test_run_workflow_passes_runtime_settings_through_to_executor(monkeypatch):
-    seen: dict[str, Any] = {}
+def test_run_workflow_injects_default_agent_before_execution(monkeypatch):
+    seen_step_definition: dict[str, Any] = {}
 
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
-        seen["default_agent"] = default_agent
-        seen["inactivity_timeout_seconds"] = inactivity_timeout_seconds
-        seen["graceful_shutdown_timeout_seconds"] = graceful_shutdown_timeout_seconds
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+        seen_step_definition.update(step_definition)
         return StepResult(
-            step_name=step_name,
             status="completed",
-            output={"value": step_name},
-            agent_name=default_agent,
+            output={"value": "draft"},
+            agent_name=step_definition["agent"],
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -217,34 +179,18 @@ def test_run_workflow_passes_runtime_settings_through_to_executor(monkeypatch):
                 "prompt": "Write a draft.",
                 "output": {"value": "draft"},
             }
-        },
-        default_agent="test-agent",
-        inactivity_timeout_seconds=12,
-        graceful_shutdown_timeout_seconds=7,
+        }
     )
 
     assert result.status == "completed"
-    assert seen == {
-        "default_agent": "test-agent",
-        "inactivity_timeout_seconds": 12,
-        "graceful_shutdown_timeout_seconds": 7,
-    }
+    assert seen_step_definition["agent"] == "codex"
 
 
 def test_run_workflow_rejects_completed_step_without_agent_name(monkeypatch):
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
         return StepResult(
-            step_name=step_name,
             status="completed",
-            output={"value": step_name},
+            output={"value": step_definition["prompt"]},
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -262,29 +208,19 @@ def test_run_workflow_rejects_completed_step_without_agent_name(monkeypatch):
 
 
 def test_run_workflow_stores_null_input_for_completed_steps(monkeypatch):
-    def fake_execute_step(
-        step_name: str,
-        step_definition: dict[str, Any],
-        *,
-        prior_steps,
-        default_agent: str,
-        inactivity_timeout_seconds: int,
-        graceful_shutdown_timeout_seconds: int,
-    ) -> StepResult:
-        if step_name == "draft":
+    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+        if step_definition["prompt"] == "Write a draft.":
             return StepResult(
-                step_name=step_name,
                 status="completed",
                 output={"title": "Draft Title"},
                 resolved_input=None,
-                agent_name=default_agent,
+                agent_name=step_definition["agent"],
             )
         return StepResult(
-            step_name=step_name,
             status="completed",
             output={"reviewed_title": "Reviewed Draft Title"},
             resolved_input=None,
-            agent_name=default_agent,
+            agent_name=step_definition["agent"],
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -323,4 +259,3 @@ def test_run_workflow_stores_null_input_for_completed_steps(monkeypatch):
             "output": {"reviewed_title": "Reviewed Draft Title"},
         },
     }
-

--- a/tests/test_workflow_engine.py
+++ b/tests/test_workflow_engine.py
@@ -11,12 +11,18 @@ from myteam.workflow.models import StepResult
 def test_run_workflow_executes_steps_in_authored_order(monkeypatch):
     calls: list[str] = []
 
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
-        calls.append(step_definition["prompt"])
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
+        calls.append(prompt)
         return StepResult(
             status="completed",
-            output={"value": step_definition["output"]["value"]},
-            agent_name=step_definition["agent"],
+            output={"value": output["value"]},
+            agent_name=agent,
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -43,9 +49,15 @@ def test_run_workflow_executes_steps_in_authored_order(monkeypatch):
 def test_run_workflow_stops_at_first_failed_step(monkeypatch):
     calls: list[str] = []
 
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
-        calls.append(step_definition["prompt"])
-        if step_definition["prompt"] == "two":
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
+        calls.append(prompt)
+        if prompt == "two":
             return StepResult(
                 status="failed",
                 error_type="completion_missing",
@@ -53,8 +65,8 @@ def test_run_workflow_stops_at_first_failed_step(monkeypatch):
             )
         return StepResult(
             status="completed",
-            output={"value": step_definition["output"]["value"]},
-            agent_name=step_definition["agent"],
+            output={"value": output["value"]},
+            agent_name=agent,
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -93,19 +105,32 @@ def test_run_workflow_stops_at_first_failed_step(monkeypatch):
 def test_run_workflow_stores_completed_step_state_for_later_references(monkeypatch):
     seen_step_definitions: list[dict[str, Any]] = []
 
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
-        seen_step_definitions.append(step_definition)
-        if step_definition["prompt"] == "Write a draft.":
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
+        seen_step_definitions.append(
+            {
+                "agent": agent,
+                "input": input,
+                "output": output,
+                "prompt": prompt,
+            }
+        )
+        if prompt == "Write a draft.":
             return StepResult(
                 status="completed",
                 output={"title": "Draft Title"},
-                agent_name=step_definition["agent"],
+                agent_name=agent,
             )
         return StepResult(
             status="completed",
             output={"reviewed_title": "Reviewed Draft Title"},
             resolved_input={"title": "Draft Title"},
-            agent_name=step_definition["agent"],
+            agent_name=agent,
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -163,12 +188,25 @@ def test_run_workflow_stores_completed_step_state_for_later_references(monkeypat
 def test_run_workflow_injects_default_agent_before_execution(monkeypatch):
     seen_step_definition: dict[str, Any] = {}
 
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
-        seen_step_definition.update(step_definition)
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
+        seen_step_definition.update(
+            {
+                "agent": agent,
+                "input": input,
+                "output": output,
+                "prompt": prompt,
+            }
+        )
         return StepResult(
             status="completed",
             output={"value": "draft"},
-            agent_name=step_definition["agent"],
+            agent_name=agent,
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -187,10 +225,16 @@ def test_run_workflow_injects_default_agent_before_execution(monkeypatch):
 
 
 def test_run_workflow_rejects_completed_step_without_agent_name(monkeypatch):
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
         return StepResult(
             status="completed",
-            output={"value": step_definition["prompt"]},
+            output={"value": prompt},
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)
@@ -208,19 +252,25 @@ def test_run_workflow_rejects_completed_step_without_agent_name(monkeypatch):
 
 
 def test_run_workflow_stores_null_input_for_completed_steps(monkeypatch):
-    def fake_execute_step(step_definition: dict[str, Any]) -> StepResult:
-        if step_definition["prompt"] == "Write a draft.":
+    def fake_execute_step(
+        *,
+        prompt: str,
+        output: dict[str, Any],
+        input: Any,
+        agent: str,
+    ) -> StepResult:
+        if prompt == "Write a draft.":
             return StepResult(
                 status="completed",
                 output={"title": "Draft Title"},
                 resolved_input=None,
-                agent_name=step_definition["agent"],
+                agent_name=agent,
             )
         return StepResult(
             status="completed",
             output={"reviewed_title": "Reviewed Draft Title"},
             resolved_input=None,
-            agent_name=step_definition["agent"],
+            agent_name=agent,
         )
 
     monkeypatch.setattr("myteam.workflow.engine.execute_step", fake_execute_step)

--- a/tests/test_workflow_flow.py
+++ b/tests/test_workflow_flow.py
@@ -100,6 +100,35 @@ def test_start_accepts_yml_extension(run_myteam_inprocess, initialized_project: 
     assert seen["path"] == workflow_file
 
 
+def test_start_runs_python_workflow_file(run_myteam_inprocess, initialized_project: Path):
+    workflow_file = initialized_project / ".myteam" / "demo.py"
+    workflow_file.write_text(
+        "from pathlib import Path\n"
+        "\n"
+        "def main():\n"
+        "    Path('workflow_ran.txt').write_text('ok', encoding='utf-8')\n",
+        encoding="utf-8",
+    )
+
+    result = run_myteam_inprocess(initialized_project, "start", "demo")
+
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert (initialized_project / "workflow_ran.txt").read_text(encoding="utf-8") == "ok"
+
+
+def test_start_fails_for_python_workflow_without_main(run_myteam_inprocess, initialized_project: Path):
+    workflow_file = initialized_project / ".myteam" / "demo.py"
+    workflow_file.write_text("VALUE = 1\n", encoding="utf-8")
+
+    result = run_myteam_inprocess(initialized_project, "start", "demo")
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "must define a callable main()" in result.stderr
+
+
 def test_start_fails_when_workflow_file_is_missing(run_myteam_inprocess, initialized_project: Path):
     result = run_myteam_inprocess(initialized_project, "start", "missing")
 

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ wheels = [
 
 [[package]]
 name = "myteam"
-version = "0.2.12"
+version = "0.2.14"
 source = { editable = "." }
 dependencies = [
     { name = "fire" },


### PR DESCRIPTION
the signature for `execute_step` is now `def execute_step(step_definition: StepDefinition) -> StepResult:` and is now distinct from the yaml-driven workflows