### PR TITLE
Document governing scenarios

### DIFF
--- a/src/governing_docs/application_interface.md
+++ b/src/governing_docs/application_interface.md
@@ -74,6 +74,36 @@ Successful commands either:
 
 When a command cannot complete, it exits with an error and reports the failure on standard error.
 
+## Scenario Documentation
+
+The detailed externally observable behavior is organized as scenario-style
+documentation under [scenarios/](scenarios/). These scenarios preserve the
+current application contract while grouping related command variants into
+domain-oriented files:
+
+- [Local tree management](scenarios/local_tree/manages_local_tree.md) covers
+  initialization, role and skill scaffolding, and removal.
+- [Selected local roots](scenarios/local_tree/uses_selected_local_root.md)
+  covers `--prefix` behavior across supported commands.
+- [Instruction loading](scenarios/instruction_loading/loads_instruction_nodes.md)
+  covers role loading, skill loading, and built-in skill resolution.
+- [Upgrade guidance](scenarios/instruction_loading/surfaces_upgrade_guidance.md)
+  covers tracked-version notices and built-in maintenance skills.
+- [Workflow execution](scenarios/workflows/runs_workflows.md) covers starting
+  YAML and Python workflows.
+- [Workflow definition validation](scenarios/workflows/validates_workflow_definitions.md)
+  covers YAML shape rules and reference semantics.
+- [Workflow result submission](scenarios/workflows/submits_workflow_results.md)
+  covers the agent-facing `myteam workflow-result` contract.
+- [Roster management](scenarios/rosters/manages_rosters.md) covers listing,
+  downloading, and updating managed roster installs.
+- [CLI status reporting](scenarios/diagnostics/reports_cli_status.md) covers
+  version output and command failure reporting.
+
+The command reference below remains as the existing supported command surface.
+Scenario files are the preferred place to maintain detailed behavior, failure
+conditions, and operational contracts.
+
 ## Command Reference
 
 ### `myteam init [--prefix <path>]`

--- a/src/governing_docs/scenarios/README.md
+++ b/src/governing_docs/scenarios/README.md
@@ -1,0 +1,38 @@
+# Myteam Interface Scenarios
+
+Scenario documentation is the authoritative documentation model for
+externally observable `myteam` behavior.
+
+# Context
+
+`myteam` is a command-line application for building file-based agent systems.
+It operates relative to the current working directory, treats that directory as
+the project root, and uses a selected project-local root for commands that
+create, load, remove, download, update, or start local agent-system objects.
+
+The default project-local root is `.myteam/`. Supported commands can select a
+different local root with `--prefix <path>`.
+
+Roles, skills, workflows, tools, and managed roster installs are represented by
+files and directories. Callers interact with those objects through the CLI and
+observe behavior through standard output, standard error, exit status, and
+filesystem changes under the current project.
+
+# Scenario Groups
+
+- [Local tree management](local_tree/manages_local_tree.md)
+- [Selected local roots](local_tree/uses_selected_local_root.md)
+- [Instruction loading](instruction_loading/loads_instruction_nodes.md)
+- [Upgrade guidance](instruction_loading/surfaces_upgrade_guidance.md)
+- [Workflow execution](workflows/runs_workflows.md)
+- [Workflow definition validation](workflows/validates_workflow_definitions.md)
+- [Workflow result submission](workflows/submits_workflow_results.md)
+- [Roster management](rosters/manages_rosters.md)
+- [CLI status reporting](diagnostics/reports_cli_status.md)
+
+# Non-Goals
+
+These scenarios do not define internal module boundaries, template
+implementation details, private helper behavior, the prose content of any
+project's role or skill instructions, or the contents of any external roster
+repository.

--- a/src/governing_docs/scenarios/diagnostics/reports_cli_status.md
+++ b/src/governing_docs/scenarios/diagnostics/reports_cli_status.md
@@ -1,0 +1,45 @@
+# Reports CLI Status
+
+## Purpose
+
+Report version and failures.
+
+---
+
+# Context
+
+Callers observe CLI status through standard output, standard error, exit
+status, and filesystem effects.
+
+---
+
+# Action
+
+The caller asks for the installed version or runs a command that succeeds or
+fails.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam --version` | Prints a version string in the form `myteam <version>`. |
+| Successful command | Creates or removes files, prints instructions or listings, executes a workflow, downloads roster files, or returns a version string according to the command contract. |
+| Failed command | Exits with an error and reports the failure on standard error. |
+
+---
+
+# Outcome
+
+The caller can verify which installed version of `myteam` is running.
+
+Errors are communicated as command failure plus an error message on standard
+error. Command-specific scenario files define the failure conditions that matter
+for each behavior.
+
+---
+
+# Related Scenarios
+
+- [../README.md](../README.md)

--- a/src/governing_docs/scenarios/instruction_loading/loads_instruction_nodes.md
+++ b/src/governing_docs/scenarios/instruction_loading/loads_instruction_nodes.md
@@ -1,0 +1,58 @@
+# Loads Instruction Nodes
+
+## Purpose
+
+Load roles and skills.
+
+---
+
+# Context
+
+Role directories contain `role.md` or `ROLE.md` and a `load.py`. Skill
+directories contain `skill.md` or `SKILL.md` and a `load.py`. Instruction files
+may contain YAML frontmatter; frontmatter is not shown in loaded instructions.
+
+Non-built-in role and skill paths resolve from the selected local root.
+Packaged built-in skills resolve from the reserved `builtins/` namespace.
+
+---
+
+# Action
+
+The caller asks `myteam` to load a role or skill.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam get role` | Loads the root role at the selected local root. |
+| `myteam get role <path>` | Loads the nested role under the selected local root. |
+| `myteam get skill <path>` | Resolves and loads the skill from the selected local root. |
+| `myteam get skill builtins/...` | Resolves and loads the skill from the packaged built-in tree. |
+
+---
+
+# Outcome
+
+The command executes the resolved node's `load.py`, prints the node
+instructions, and prints immediately discoverable child roles, child skills,
+and Python tools exposed by that loader.
+
+When the loader includes built-in explanation text for roles, skills, and
+tools, the command prints that guidance as part of the loaded role or skill
+output.
+
+The command exits with an error when the target path is not a valid role or
+skill directory, when the resolved node lacks the required loader entry point,
+or when the loader exits non-zero. Loader exit status propagates as command
+failure.
+
+---
+
+# Related Scenarios
+
+- [surfaces_upgrade_guidance.md](surfaces_upgrade_guidance.md)
+- [../local_tree/manages_local_tree.md](../local_tree/manages_local_tree.md)
+- [../local_tree/uses_selected_local_root.md](../local_tree/uses_selected_local_root.md)

--- a/src/governing_docs/scenarios/instruction_loading/surfaces_upgrade_guidance.md
+++ b/src/governing_docs/scenarios/instruction_loading/surfaces_upgrade_guidance.md
@@ -1,0 +1,52 @@
+# Surfaces Upgrade Guidance
+
+## Purpose
+
+Expose version-aware maintenance help.
+
+---
+
+# Context
+
+A local tree may contain tracked-version metadata recording the `myteam`
+version that initialized or refreshed that tree. The installed `myteam` package
+also ships built-in maintenance skills under the reserved `builtins/`
+namespace.
+
+---
+
+# Action
+
+The caller loads the generated root role or a packaged built-in maintenance
+skill.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam get role` with an older tracked local tree | The generated root role can alert the caller that the installed `myteam` release is newer than the stored tracked version. |
+| `myteam get role` with missing tracked-version metadata | The generated root role treats the selected local tree as an untracked legacy tree and may still print upgrade guidance instead of failing. |
+| Root-role migration notice | The generated root role can tell the caller that it may assist with migration and should load `myteam get skill builtins/migration` if the user agrees. |
+| `myteam get skill builtins/migration` | Prints packaged migration guidance for the selected local tree context. |
+| `myteam get skill builtins/changelog` | Prints release notes derived from the installed `myteam` package. |
+
+---
+
+# Outcome
+
+Upgrade guidance is surfaced through the generated root role and built-in
+maintenance skills, not through a dedicated migration CLI command.
+
+Built-in maintenance skills are available without being copied into the
+project-local tree. If tracked-version metadata is missing, upgrade-related
+built-in loaders treat the tree as a legacy untracked local tree rather than
+failing solely because the version file is absent.
+
+---
+
+# Related Scenarios
+
+- [loads_instruction_nodes.md](loads_instruction_nodes.md)
+- [../local_tree/manages_local_tree.md](../local_tree/manages_local_tree.md)

--- a/src/governing_docs/scenarios/local_tree/manages_local_tree.md
+++ b/src/governing_docs/scenarios/local_tree/manages_local_tree.md
@@ -1,0 +1,57 @@
+# Manages Local Tree
+
+## Purpose
+
+Create and remove local agent-system nodes.
+
+---
+
+# Context
+
+`myteam` is run from a project root. The command uses the selected local root,
+which defaults to `.myteam/` unless the invocation selects another root.
+
+Role and skill paths are slash-delimited and describe directories below the
+selected local root.
+
+---
+
+# Action
+
+The caller runs a command that initializes the local tree, scaffolds a role or
+skill, or removes an existing local node.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam init` | Creates the selected local root as the root role directory when needed, creates `role.md`, `load.py`, and the tracked-version metadata file in that root, creates `AGENTS.md` when absent, and leaves an existing `AGENTS.md` in place. |
+| `myteam new role <path>` | Creates the target directory under the selected local root with a `role.md` definition file and a `load.py` loader. |
+| `myteam new skill <path>` | Creates the target directory under the selected local root with a `skill.md` definition file and a `load.py` loader. |
+| `myteam remove <path>` | Deletes the target role or skill directory and all of its contents from the selected local root. |
+
+---
+
+# Outcome
+
+After initialization succeeds, the current directory is ready for
+`myteam get role`, and packaged maintenance skills under the reserved
+`builtins/` namespace are available without being copied into the project tree.
+
+After role or skill scaffolding succeeds, the new node is loadable with
+`myteam get role <path>` or `myteam get skill <path>`.
+
+After removal succeeds, the removed node is no longer available to load.
+
+The command exits with an error and reports the failure on standard error when
+the target already exists during scaffolding, does not exist during removal, is
+not a directory during removal, or cannot be removed.
+
+---
+
+# Related Scenarios
+
+- [uses_selected_local_root.md](uses_selected_local_root.md)
+- [../instruction_loading/loads_instruction_nodes.md](../instruction_loading/loads_instruction_nodes.md)

--- a/src/governing_docs/scenarios/local_tree/uses_selected_local_root.md
+++ b/src/governing_docs/scenarios/local_tree/uses_selected_local_root.md
@@ -1,0 +1,56 @@
+# Uses Selected Local Root
+
+## Purpose
+
+Honor caller-selected local roots.
+
+---
+
+# Context
+
+Commands that operate on the project-local tree use one selected local root for
+that invocation. The default local root is `.myteam/`. Packaged built-in skills
+live outside the project-local tree under the reserved `builtins/` namespace.
+
+---
+
+# Action
+
+The caller passes `--prefix <path>` to a command that supports local root
+selection.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam init --prefix <path>` | Initializes the root role in the selected local root instead of `.myteam/`. |
+| `myteam new role <name> --prefix <path>` | Creates the role under the selected local root. |
+| `myteam new skill <name> --prefix <path>` | Creates the skill under the selected local root. |
+| `myteam get role ... --prefix <path>` | Resolves non-built-in roles from the selected local root. |
+| `myteam get skill <name> --prefix <path>` | Resolves non-built-in skills from the selected local root. |
+| `myteam get skill builtins/... --prefix <path>` | Resolves the built-in skill from the packaged built-in tree while preserving the selected local root as project context for the loader. |
+| `myteam remove <name> --prefix <path>` | Removes the target node from the selected local root. |
+| `myteam download <roster> --prefix <path>` | Uses the selected local root as the default managed-install destination when no explicit destination is provided. |
+| `myteam update [path] --prefix <path>` | Searches for or resolves managed installs under the selected local root. |
+| `myteam start <workflow> --prefix <path>` | Resolves the workflow file from the selected local root. |
+
+---
+
+# Outcome
+
+`--prefix` changes only the project-local root used by that command invocation.
+It does not change where packaged built-in skills are stored or resolved from.
+
+When a command accepts both `--prefix` and a more specific path-like input, the
+specific path-like input still determines the final target documented by that
+command.
+
+---
+
+# Related Scenarios
+
+- [../instruction_loading/loads_instruction_nodes.md](../instruction_loading/loads_instruction_nodes.md)
+- [../workflows/runs_workflows.md](../workflows/runs_workflows.md)
+- [../rosters/manages_rosters.md](../rosters/manages_rosters.md)

--- a/src/governing_docs/scenarios/rosters/manages_rosters.md
+++ b/src/governing_docs/scenarios/rosters/manages_rosters.md
@@ -1,0 +1,62 @@
+# Manages Rosters
+
+## Purpose
+
+List, download, and update rosters.
+
+---
+
+# Context
+
+A roster is downloadable content from a remote repository. A managed local
+roster install records source provenance in a `.source.yml` file at the root of
+the managed folder.
+
+---
+
+# Action
+
+The caller lists available rosters, downloads a roster, or updates managed
+downloaded roster content.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `myteam list` | Connects to the configured roster repository and prints one available roster entry path per line. |
+| `myteam download <roster>` without a destination | Installs the roster under the selected local root using the same relative folder path as the remote roster. |
+| `myteam download <roster> [destination]` | Downloads the requested roster folder content into one managed local folder, writes `.source.yml`, preserves relative file paths from the roster, and prints progress. |
+| `myteam update <path>` | Refreshes the managed folder rooted at the selected local root from its recorded source metadata. |
+| `myteam update` without a path | Scans the selected local root recursively for managed download roots and updates each one independently. |
+
+---
+
+# Outcome
+
+Downloaded content becomes available on disk as a managed folder, ready to be
+loaded or edited. The managed folder records enough source information for
+later provenance-aware updates.
+
+During update, `myteam` reads `.source.yml` from each targeted managed folder,
+re-downloads content from the recorded repository, roster path, and ref,
+deletes existing content at the managed target before re-download, and then
+performs the same managed install behavior as `download` using the recorded
+source metadata.
+
+The command exits with an error when roster listing cannot reach a valid remote
+repository, when a requested roster does not exist, when a requested roster
+resolves to a single file instead of a folder, when the destination already
+contains the same managed source and should be updated instead, when unrelated
+content already exists at the destination, when remote metadata or downloads
+fail, when an update target lacks `.source.yml`, when no managed folders are
+found for a root update, when source metadata is invalid or incomplete, or when
+the recorded remote roster no longer exists, resolves to a file, or cannot be
+fetched.
+
+---
+
+# Related Scenarios
+
+- [../local_tree/uses_selected_local_root.md](../local_tree/uses_selected_local_root.md)

--- a/src/governing_docs/scenarios/workflows/runs_workflows.md
+++ b/src/governing_docs/scenarios/workflows/runs_workflows.md
@@ -1,0 +1,60 @@
+# Runs Workflows
+
+## Purpose
+
+Execute authored workflows.
+
+---
+
+# Context
+
+Workflow definitions are stored in the selected local root. A workflow path is
+slash-delimited, such as `dev/frontend`, and resolves to a supported workflow
+file in that local root.
+
+Supported workflow files include YAML files ending in `.yaml` or `.yml` and
+Python workflow files ending in `.py`.
+
+---
+
+# Action
+
+The caller runs `myteam start <path> [--prefix <path>] [--verbose]`.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| Start a YAML workflow | Loads and validates the authored YAML definition, executes steps in authored order, supplies each configured workflow agent with the authored step prompt, stores completed step state for later references, and returns success only after all steps complete. |
+| Start a Python workflow | Executes the workflow file as a separate Python process using the active Python executable and propagates the process exit status. |
+| A step fails | Stops at the first failing step, does not execute later steps, and exits with an error. |
+| `--verbose` | Enables workflow lifecycle logging on standard error. |
+
+---
+
+# Outcome
+
+Workflow execution mirrors the child session's terminal output to standard
+output as the workflow runs and reports command failures on standard error.
+
+Successful YAML workflow completion does not currently emit an additional final
+workflow-result payload on standard output.
+
+For Python workflows, the child process working directory is the directory
+containing the workflow file. The Python workflow is responsible for invoking
+its own entry point, such as with an `if __name__ == "__main__":` block.
+
+The command exits with an error when the workflow path does not resolve to a
+workflow file with a supported extension, when the workflow definition is
+malformed, when the definition references an unknown agent, when any workflow
+step fails, or when a Python workflow process exits non-zero.
+
+---
+
+# Related Scenarios
+
+- [validates_workflow_definitions.md](validates_workflow_definitions.md)
+- [submits_workflow_results.md](submits_workflow_results.md)
+- [../local_tree/uses_selected_local_root.md](../local_tree/uses_selected_local_root.md)

--- a/src/governing_docs/scenarios/workflows/submits_workflow_results.md
+++ b/src/governing_docs/scenarios/workflows/submits_workflow_results.md
@@ -1,0 +1,52 @@
+# Submits Workflow Results
+
+## Purpose
+
+Submit structured step results.
+
+---
+
+# Context
+
+`myteam workflow-result` is primarily intended for workflow agents running
+inside an active workflow step. The active workflow environment provides result
+socket metadata and a token that allow the step to submit its final structured
+result to the parent workflow runner.
+
+---
+
+# Action
+
+The agent runs `myteam workflow-result [--json <json> | --text <text>]`, or
+runs `myteam workflow-result` with JSON provided on standard input.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| `--json <json>` | Uses the provided argument as the JSON payload. |
+| `--text <text>` | Wraps the text as `{"text": <text>}`. |
+| No flag with JSON on standard input | Reads the JSON payload from standard input. |
+
+---
+
+# Outcome
+
+On success, the command reads the workflow result socket path and token from
+the current process environment, validates the provided payload input, sends the
+payload once to the parent workflow runner for the active step, and prints a
+short confirmation message.
+
+The command exits with an error when both `--json` and `--text` are provided,
+when no payload is provided and standard input is empty, when the environment
+does not contain workflow result socket metadata, when the parent runner
+rejects the payload, or when acknowledgement is invalid.
+
+---
+
+# Related Scenarios
+
+- [runs_workflows.md](runs_workflows.md)
+- [validates_workflow_definitions.md](validates_workflow_definitions.md)

--- a/src/governing_docs/scenarios/workflows/validates_workflow_definitions.md
+++ b/src/governing_docs/scenarios/workflows/validates_workflow_definitions.md
@@ -1,0 +1,63 @@
+# Validates Workflow Definitions
+
+## Purpose
+
+Define authored workflow shape.
+
+---
+
+# Context
+
+YAML workflow files are user-authored files stored in the selected local root.
+They define ordered workflow steps and may reference completed state from
+earlier steps.
+
+---
+
+# Action
+
+The caller starts a YAML workflow or otherwise causes `myteam` to load and
+validate a YAML workflow definition.
+
+---
+
+# Interaction
+
+| Action | Outcome |
+| --- | --- |
+| Top-level YAML mapping | Each top-level key is treated as a workflow step name. |
+| Step mapping with `prompt`, optional `input`, optional `agent`, and `output` | The step is valid when all workflow shape rules are satisfied. |
+| Omitted `agent` | The default shipped agent is used. |
+| `output` mapping with nested objects | The final step result must contain the same nested keys. |
+| Output-template leaf values | Leaf values are treated as descriptive placeholders and do not constrain the final JSON value type. |
+| Full-string reference such as `$step.output.value` inside `input` | Resolves against previously completed step state and inserts the resolved value as structured data. |
+| Exact scalar value `$$` prefix | Escapes a literal leading dollar. |
+
+---
+
+# Outcome
+
+Workflow files do not use a top-level `steps:` wrapper. Steps execute in the
+order they are authored in the file. Step names and authored nested keys that
+participate in the workflow format and reference system must use valid
+identifier-style names.
+
+Reference expressions start with `$`. The token immediately after `$` is the
+earlier step name. Additional dotted path components select nested object keys
+from that step's stored completed state. References resolve only against
+previously completed steps. Objects and arrays remain objects and arrays when
+inserted through a reference.
+
+Missing paths are errors. Reference traversal supports object keys, not array
+indexes. Partial string interpolation is not supported. Forward references and
+self-references are invalid at execution time.
+
+The step agent must report the final structured result through
+`myteam workflow-result` rather than terminal markers or free-form prose.
+
+---
+
+# Related Scenarios
+
+- [runs_workflows.md](runs_workflows.md)
+- [submits_workflow_results.md](submits_workflow_results.md)


### PR DESCRIPTION
Closes #79

## Summary
- Keep application_interface.md as the top-level governing-doc interface and scenario index.
- Add scenario-style governing docs for local tree management, instruction loading, workflows, rosters, and diagnostics.
- Preserve this as documentation-only work with no runtime or package metadata changes.

## Verification
- git diff --check