### PR TITLE
Retry malformed output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "myteam"
-version = "0.2.24"
+version = "0.2.25"
 description = "Agent roster CLI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/myteam/CHANGELOG.md
+++ b/src/myteam/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.2.25
+
+- Fixed workflow output shape enforcing order. Before, the agent session was closed before shape
+  validation. Now it validates the shape before closing the session, allowing the agent to retry.
+
 ## 0.2.24
 
 - Fixed role and skill loaders so listed tool paths stay rooted at the project tree, which keeps

--- a/src/myteam/workflow/steps.py
+++ b/src/myteam/workflow/steps.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -155,6 +156,7 @@ class AgentContext:
         session_result = run_terminal_session(
             prepared.argv,
             exit_input=prepared.agent_config.exit_sequence,
+            payload_validator=_build_payload_validator(prepared.output_template),
             cwd=self.launch_cwd,
             inactivity_timeout_seconds=self.timeout,
         )
@@ -429,6 +431,7 @@ def _build_step_prompt(
         sections.extend([
             "Return the final workflow result by calling this command:",
             "Replace the placeholder values below with the real final result content.",
+            "If the command reports an output format mismatch, correct the payload and try again.",
             "",
             "myteam workflow-result <<'JSON'",
             json.dumps(output_template, indent=2),
@@ -492,6 +495,19 @@ def _extract_session_id(output_value: Any) -> str | None:
     if isinstance(value, str) and value:
         return value
     return None
+
+
+def _build_payload_validator(output_template: dict[str, Any]) -> Callable[[Any], str | None]:
+    expected_output = json.dumps(output_template, indent=2)
+
+    def validate(payload: Any) -> str | None:
+        try:
+            validate_step_output(output_template, payload)
+        except ValueError:
+            return "output format mismatch\nRequired output format:\n" + expected_output
+        return None
+
+    return validate
 
 
 class StepExecutionError(Exception):

--- a/src/myteam/workflow/terminal/result_channel.py
+++ b/src/myteam/workflow/terminal/result_channel.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable
 import json
 import os
 import secrets
@@ -16,7 +16,11 @@ RESULT_TOKEN_ENV = "MYTEAM_RESULT_TOKEN"
 
 
 class ResultChannel:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        payload_validator: Callable[[Any], str | None] | None = None,
+    ) -> None:
         self.socket_path = ""
         self.token = secrets.token_urlsafe(18)
         self.payload: Any | None = None
@@ -25,6 +29,7 @@ class ResultChannel:
         self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
         self._server: socket.socket | None = None
         self._thread: threading.Thread | None = None
+        self._payload_validator = payload_validator
 
     def __enter__(self) -> "ResultChannel":
         self._tmpdir = tempfile.TemporaryDirectory(prefix="myteam-workflow-")
@@ -94,7 +99,13 @@ class ResultChannel:
         if self._result_ready.is_set():
             return {"ok": False, "error": "Workflow result already recorded."}
 
-        self.payload = message["payload"]
+        payload = message["payload"]
+        if self._payload_validator is not None:
+            error_message = self._payload_validator(payload)
+            if error_message is not None:
+                return {"ok": False, "error": error_message}
+
+        self.payload = payload
         self._result_ready.set()
         return {"ok": True}
 

--- a/src/myteam/workflow/terminal/session.py
+++ b/src/myteam/workflow/terminal/session.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 import threading
+from typing import Any
 
 from .pty_session import PtySession
 from .recording import TerminalRecording
@@ -21,11 +22,12 @@ def run_terminal_session(
     argv: list[str],
     *,
     exit_input: bytes,
+    payload_validator: Callable[[Any], str | None] | None = None,
     cwd: Path | str | None = None,
     inactivity_timeout_seconds: int = 300,
 ) -> TerminalSessionResult:
     recording = TerminalRecording()
-    with ResultChannel() as result_channel:
+    with ResultChannel(payload_validator=payload_validator) as result_channel:
         with PtySession(
             argv,
             env=result_channel.env,

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -140,6 +140,7 @@ def test_agent_context_aggregates_usage_across_runs(monkeypatch, capsys):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -193,6 +194,7 @@ def test_run_agent_returns_completed_result(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -233,6 +235,7 @@ def test_run_agent_marks_missing_usage_hook_as_not_implemented(monkeypatch, caps
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -374,6 +377,7 @@ def test_run_agent_preserves_literal_input(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -406,6 +410,7 @@ def test_run_agent_passes_extra_args_to_build_argv(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -534,6 +539,7 @@ def test_run_agent_resumes_session_and_preserves_session_id(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -568,6 +574,7 @@ def test_run_agent_forks_session_and_discovers_new_session_id(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -602,6 +609,7 @@ def test_run_agent_passes_interactive_false_to_build_argv(monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -751,6 +759,7 @@ def test_run_agent_attaches_usage_and_prints_summary(monkeypatch, capsys):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -796,6 +805,7 @@ def test_run_agent_records_unavailable_usage_lookup(monkeypatch, capsys):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -923,6 +933,7 @@ def test_run_agent_launches_from_project_root_when_called_under_active_root(tmp_
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -971,6 +982,7 @@ def test_run_agent_resolves_project_root_from_requested_cwd(tmp_path, monkeypatc
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:
@@ -1019,6 +1031,7 @@ def test_run_agent_allows_launch_cwd_override(tmp_path, monkeypatch):
         argv: list[str],
         *,
         exit_input: bytes,
+        payload_validator=None,
         cwd,
         inactivity_timeout_seconds: int,
     ) -> TerminalSessionResult:

--- a/tests/test_terminal_result_channel.py
+++ b/tests/test_terminal_result_channel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from myteam.workflow.terminal.result_channel import ResultChannel, submit_result_payload
@@ -15,3 +17,23 @@ def test_result_channel_rejects_invalid_token():
     with ResultChannel() as channel:
         with pytest.raises(ValueError, match="Invalid workflow result token"):
             submit_result_payload({"answer": "done"}, socket_path=channel.socket_path, token="wrong")
+
+
+def test_result_channel_rejects_output_shape_mismatch_until_corrected():
+    expected_format = {"answer": {}}
+
+    def validate(payload):
+        if not isinstance(payload, dict) or "answer" not in payload:
+            return "output format mismatch\nRequired output format:\n" + json.dumps(expected_format, indent=2)
+        if not isinstance(payload["answer"], dict):
+            return "output format mismatch\nRequired output format:\n" + json.dumps(expected_format, indent=2)
+        return None
+
+    with ResultChannel(payload_validator=validate) as channel:
+        with pytest.raises(ValueError, match="output format mismatch"):
+            submit_result_payload({"wrong": "shape"}, socket_path=channel.socket_path, token=channel.token)
+
+        assert channel.wait(timeout=0.1) is None
+
+        submit_result_payload({"answer": {}}, socket_path=channel.socket_path, token=channel.token)
+        assert channel.wait(timeout=1) == {"answer": {}}

--- a/tests/test_workflow_result_command.py
+++ b/tests/test_workflow_result_command.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from myteam.workflow.terminal.result_channel import ResultChannel
@@ -16,3 +17,24 @@ def test_workflow_result_reads_json_from_stdin(run_myteam_inprocess, initialized
         assert result.exit_code == 0
         assert "Workflow result accepted." in result.stdout
         assert channel.wait(timeout=1) == {"answer": "done"}
+
+
+def test_workflow_result_reports_output_format_mismatch(run_myteam_inprocess, initialized_project: Path, monkeypatch):
+    expected_format = {"answer": {}}
+
+    def validate(payload):
+        if not isinstance(payload, dict) or "answer" not in payload or not isinstance(payload["answer"], dict):
+            return "output format mismatch\nRequired output format:\n" + json.dumps(expected_format, indent=2)
+        return None
+
+    with ResultChannel(payload_validator=validate) as channel:
+        monkeypatch.setenv("MYTEAM_RESULT_SOCKET", channel.socket_path)
+        monkeypatch.setenv("MYTEAM_RESULT_TOKEN", channel.token)
+        monkeypatch.setattr("sys.stdin.read", lambda: '{"answer":"done"}')
+
+        result = run_myteam_inprocess(initialized_project, "workflow-result")
+
+        assert result.exit_code == 1
+        assert "output format mismatch" in result.stderr
+        assert "Required output format:" in result.stderr
+        assert channel.wait(timeout=0.1) is None


### PR DESCRIPTION
Fixed workflow output shape enforcing order. Before, the agent session was closed before shape validation. Now it validates the shape before closing the session, allowing the agent to retry.